### PR TITLE
AIM object update notifications

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ alembic
 Click
 oslo.config
 oslo.db
+oslo.log
 pbr>=1.6


### PR DESCRIPTION
AimManager now allows specifying callbacks to be invoked
when AIM objects are updated in the database. The notifications
are sent before transaction is committed. This allows the
callbacks to make additional changes to the database in the
same transaction.

Signed-off-by: Amit Bose amitbose@gmail.com
