### PR TITLE
Define resources for subnet, VRF, endpoint-groups

### DIFF
--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -50,7 +50,12 @@ class AimManager(object):
     """
 
     _db_model_map = {api_res.BridgeDomain: models.BridgeDomain,
-                     api_res.Agent: agent_model.Agent}
+                     api_res.Agent: agent_model.Agent,
+                     api_res.Tenant: models.Tenant,
+                     api_res.Subnet: models.Subnet,
+                     api_res.VRF: models.VRF,
+                     api_res.ApplicationProfile: models.ApplicationProfile,
+                     api_res.EndpointGroup: models.EndpointGroup, }
 
     def __init__(self):
         # TODO(amitbose): initialize anything we need, for example DB stuff

--- a/aim/db/migration/alembic_migrations/versions/7349fa0a2ad8_epg.py
+++ b/aim/db/migration/alembic_migrations/versions/7349fa0a2ad8_epg.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Create table for tenant, subnet, vrf, app-profile and EPG.
+
+Revision ID: 7349fa0a2ad8
+Revises: accfe645090a
+Create Date: 2016-04-05 17:59:18.910872
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7349fa0a2ad8'
+down_revision = 'accfe645090a'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'aim_tenants',
+        sa.Column('name', sa.String(64), nullable=False),
+        sa.Column('display_name', sa.String(256)),
+        sa.PrimaryKeyConstraint('name'))
+
+    op.create_table(
+        'aim_subnets',
+        sa.Column('bd_name', sa.String(64), nullable=False),
+        sa.Column('tenant_name', sa.String(64), nullable=False),
+        sa.Column('gw_ip_mask', sa.String(64), nullable=False),
+        sa.Column('display_name', sa.String(256)),
+        sa.Column('scope', sa.String(16)),
+        sa.PrimaryKeyConstraint('gw_ip_mask', 'bd_name', 'tenant_name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name', 'bd_name'],
+            ['aim_bridge_domains.tenant_name', 'aim_bridge_domains.name'],
+            name='fk_bd'))
+
+    op.create_table(
+        'aim_vrfs',
+        sa.Column('name', sa.String(64), nullable=False),
+        sa.Column('tenant_name', sa.String(64), nullable=False),
+        sa.Column('display_name', sa.String(256)),
+        sa.Column('policy_enforcement_pref', sa.Integer),
+        sa.PrimaryKeyConstraint('name', 'tenant_name'))
+
+    op.create_table(
+        'aim_app_profiles',
+        sa.Column('name', sa.String(64), nullable=False),
+        sa.Column('tenant_name', sa.String(64), nullable=False),
+        sa.Column('display_name', sa.String(256)),
+        sa.PrimaryKeyConstraint('name', 'tenant_name'))
+
+    op.create_table(
+        'aim_endpoint_groups',
+        sa.Column('name', sa.String(64), nullable=False),
+        sa.Column('app_profile_name', sa.String(64), nullable=False),
+        sa.Column('tenant_name', sa.String(64), nullable=False),
+        sa.Column('display_name', sa.String(256)),
+        sa.Column('bd_name', sa.String(64)),
+        sa.Column('bd_tenant_name', sa.String(64)),
+        sa.PrimaryKeyConstraint('name', 'app_profile_name', 'tenant_name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name', 'app_profile_name'],
+            ['aim_app_profiles.tenant_name', 'aim_app_profiles.name'],
+            name='fk_app_profile'))
+
+
+def downgrade():
+    pass

--- a/aim/db/model_base.py
+++ b/aim/db/model_base.py
@@ -19,6 +19,10 @@ from sqlalchemy.ext import declarative
 from aim.common import utils
 
 
+def name_column(**kwargs):
+    return sa.Column(sa.String(64), **kwargs)
+
+
 class AimBase(object):
     """Base class for AIM DB models.
 
@@ -35,8 +39,7 @@ class AimBase(object):
 
 class HasName(object):
 
-    name = sa.Column(sa.String(64), primary_key=True)
-    display_name = sa.Column(sa.String(256))
+    name = name_column(primary_key=True)
 
 
 class HasId(object):
@@ -45,6 +48,14 @@ class HasId(object):
     id = sa.Column(sa.String(36),
                    primary_key=True,
                    default=utils.generate_uuid)
+
+
+class HasDisplayName(object):
+    display_name = sa.Column(sa.String(256))
+
+
+class HasTenantNameKey(object):
+    tenant_name = name_column(primary_key=True)
 
 
 class AttributeMixin(object):

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -18,16 +18,79 @@ import sqlalchemy as sa
 from aim.db import model_base
 
 
+class Tenant(model_base.Base, model_base.HasName,
+             model_base.HasDisplayName, model_base.AttributeMixin):
+    """DB model for Tenant."""
+
+    __tablename__ = 'aim_tenants'
+
+
 class BridgeDomain(model_base.Base, model_base.HasName,
+                   model_base.HasDisplayName, model_base.HasTenantNameKey,
                    model_base.AttributeMixin):
     """DB model for BridgeDomain."""
 
     __tablename__ = 'aim_bridge_domains'
 
-    tenant_name = sa.Column(sa.String(64), primary_key=True)
-    vrf_name = sa.Column(sa.String(64))
+    vrf_name = model_base.name_column()
     enable_arp_flood = sa.Column(sa.Boolean)
     enable_routing = sa.Column(sa.Boolean)
     limit_ip_learn_to_subnets = sa.Column(sa.Boolean)
     l2_unknown_unicast_mode = sa.Column(sa.String(16))
     ep_move_detect_mode = sa.Column(sa.String(16))
+
+
+class Subnet(model_base.Base, model_base.HasTenantNameKey,
+             model_base.AttributeMixin):
+    """DB model for Subnet."""
+
+    __tablename__ = 'aim_subnets'
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ['tenant_name', 'bd_name'],
+            ['aim_bridge_domains.tenant_name', 'aim_bridge_domains.name'],
+            name='fk_bd'),
+        model_base.Base.__table_args__)
+
+    bd_name = model_base.name_column(primary_key=True)
+    gw_ip_mask = sa.Column(sa.String(64), primary_key=True)
+    display_name = sa.Column(sa.String(256))
+    scope = sa.Column(sa.String(16))
+
+
+class VRF(model_base.Base, model_base.HasName,
+          model_base.HasDisplayName, model_base.HasTenantNameKey,
+          model_base.AttributeMixin):
+    """DB model for BridgeDomain."""
+
+    __tablename__ = 'aim_vrfs'
+
+    policy_enforcement_pref = sa.Column(sa.Integer)
+
+
+class ApplicationProfile(model_base.Base, model_base.HasName,
+                         model_base.HasDisplayName,
+                         model_base.HasTenantNameKey,
+                         model_base.AttributeMixin):
+    """DB model for ApplicationProfile."""
+
+    __tablename__ = 'aim_app_profiles'
+
+
+class EndpointGroup(model_base.Base, model_base.HasName,
+                    model_base.HasDisplayName, model_base.HasTenantNameKey,
+                    model_base.AttributeMixin):
+    """DB model for EndpointGroup."""
+
+    __tablename__ = 'aim_endpoint_groups'
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ['tenant_name', 'app_profile_name'],
+            ['aim_app_profiles.tenant_name', 'aim_app_profiles.name'],
+            name='fk_app_profile'),
+        model_base.Base.__table_args__)
+
+    app_profile_name = model_base.name_column(primary_key=True)
+    bd_name = model_base.name_column()
+    bd_tenant_name = model_base.name_column()
+    # TODO(amitbose) Map contract names


### PR DESCRIPTION
DB-model for endpoint-groups is missing contracts.
Changes to ACI-converter are also missing.

Signed-off-by: Amit Bose <amitbose@gmail.com>