### PR TITLE
Add DB model for EPG contracts

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/40855b7eb958_create_bridgedomain_table.py
+++ b/aim/db/migration/alembic_migrations/versions/40855b7eb958_create_bridgedomain_table.py
@@ -34,6 +34,7 @@ import sqlalchemy as sa
 def upgrade():
     op.create_table(
         'aim_bridge_domains',
+        sa.Column('aim_id', sa.Integer, autoincrement=True),
         sa.Column('name', sa.String(64), nullable=False),
         sa.Column('tenant_name', sa.String(64), nullable=False),
         sa.Column('display_name', sa.String(256)),
@@ -43,7 +44,10 @@ def upgrade():
         sa.Column('limit_ip_learn_to_subnets', sa.Boolean),
         sa.Column('l2_unknown_unicast_mode', sa.String(16)),
         sa.Column('ep_move_detect_mode', sa.String(16)),
-        sa.PrimaryKeyConstraint('tenant_name', 'name'))
+        sa.PrimaryKeyConstraint('aim_id'),
+        sa.UniqueConstraint('tenant_name', 'name',
+                            name='uniq_aim_bridge_domains_identity'),
+        sa.Index('idx_aim_bridge_domains_identity', 'tenant_name', 'name'))
 
 
 def downgrade():

--- a/aim/db/model_base.py
+++ b/aim/db/model_base.py
@@ -38,8 +38,8 @@ class AimBase(object):
 
 
 class HasName(object):
-
-    name = name_column(primary_key=True)
+    """Add to subclasses that have a name (identifier)."""
+    name = name_column(nullable=False)
 
 
 class HasId(object):
@@ -50,12 +50,19 @@ class HasId(object):
                    default=utils.generate_uuid)
 
 
+class HasAimId(object):
+    """Add to subclasses that have an internal-id."""
+    aim_id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+
+
 class HasDisplayName(object):
+    """Add to subclasses that have a display name."""
     display_name = sa.Column(sa.String(256))
 
 
-class HasTenantNameKey(object):
-    tenant_name = name_column(primary_key=True)
+class HasTenantName(object):
+    """Add to subclasses that reference a tenant."""
+    tenant_name = name_column(nullable=False)
 
 
 class AttributeMixin(object):

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -14,23 +14,38 @@
 #    under the License.
 
 import sqlalchemy as sa
+from sqlalchemy import orm
 
 from aim.db import model_base
 
 
-class Tenant(model_base.Base, model_base.HasName,
-             model_base.HasDisplayName, model_base.AttributeMixin):
+def to_tuple(obj):
+    return obj if isinstance(obj, tuple) else (obj,)
+
+
+def uniq_column(table, *args):
+    return (sa.UniqueConstraint(*args, name=('uniq_%s_identity' % table)),
+            sa.Index('idx_%s_identity' % table, *args))
+
+
+class Tenant(model_base.Base, model_base.HasDisplayName,
+             model_base.AttributeMixin):
     """DB model for Tenant."""
 
     __tablename__ = 'aim_tenants'
 
+    name = model_base.name_column(primary_key=True)
 
-class BridgeDomain(model_base.Base, model_base.HasName,
-                   model_base.HasDisplayName, model_base.HasTenantNameKey,
+
+class BridgeDomain(model_base.Base, model_base.HasAimId,
+                   model_base.HasName, model_base.HasDisplayName,
+                   model_base.HasTenantName,
                    model_base.AttributeMixin):
     """DB model for BridgeDomain."""
 
     __tablename__ = 'aim_bridge_domains'
+    __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      to_tuple(model_base.Base.__table_args__))
 
     vrf_name = model_base.name_column()
     enable_arp_flood = sa.Column(sa.Boolean)
@@ -40,57 +55,102 @@ class BridgeDomain(model_base.Base, model_base.HasName,
     ep_move_detect_mode = sa.Column(sa.String(16))
 
 
-class Subnet(model_base.Base, model_base.HasTenantNameKey,
+class Subnet(model_base.Base, model_base.HasAimId,
+             model_base.HasDisplayName,
+             model_base.HasTenantName,
              model_base.AttributeMixin):
     """DB model for Subnet."""
 
     __tablename__ = 'aim_subnets'
     __table_args__ = (
-        sa.ForeignKeyConstraint(
+        uniq_column(__tablename__, 'tenant_name', 'bd_name', 'gw_ip_mask') +
+        (sa.ForeignKeyConstraint(
             ['tenant_name', 'bd_name'],
             ['aim_bridge_domains.tenant_name', 'aim_bridge_domains.name'],
-            name='fk_bd'),
-        model_base.Base.__table_args__)
+            name='fk_bd'),) +
+        to_tuple(model_base.Base.__table_args__))
 
-    bd_name = model_base.name_column(primary_key=True)
-    gw_ip_mask = sa.Column(sa.String(64), primary_key=True)
-    display_name = sa.Column(sa.String(256))
+    bd_name = model_base.name_column(nullable=False)
+    gw_ip_mask = sa.Column(sa.String(64), nullable=False)
+
     scope = sa.Column(sa.String(16))
 
 
-class VRF(model_base.Base, model_base.HasName,
-          model_base.HasDisplayName, model_base.HasTenantNameKey,
+class VRF(model_base.Base, model_base.HasAimId,
+          model_base.HasName, model_base.HasDisplayName,
+          model_base.HasTenantName,
           model_base.AttributeMixin):
     """DB model for BridgeDomain."""
 
     __tablename__ = 'aim_vrfs'
+    __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      to_tuple(model_base.Base.__table_args__))
 
     policy_enforcement_pref = sa.Column(sa.Integer)
 
 
-class ApplicationProfile(model_base.Base, model_base.HasName,
-                         model_base.HasDisplayName,
-                         model_base.HasTenantNameKey,
+class ApplicationProfile(model_base.Base, model_base.HasAimId,
+                         model_base.HasName, model_base.HasDisplayName,
+                         model_base.HasTenantName,
                          model_base.AttributeMixin):
     """DB model for ApplicationProfile."""
 
     __tablename__ = 'aim_app_profiles'
+    __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      to_tuple(model_base.Base.__table_args__))
 
 
-class EndpointGroup(model_base.Base, model_base.HasName,
-                    model_base.HasDisplayName, model_base.HasTenantNameKey,
+class EndpointGroupContract(model_base.Base):
+    """DB model for Contracts used by EndpointGroup."""
+    __tablename__ = 'aim_endpoint_group_contracts'
+
+    epg_aim_id = sa.Column(sa.Integer,
+                           sa.ForeignKey('aim_endpoint_groups.aim_id'),
+                           primary_key=True)
+    name = model_base.name_column(primary_key=True)
+    provides = sa.Column(sa.Boolean, primary_key=True)
+
+
+class EndpointGroup(model_base.Base, model_base.HasAimId,
+                    model_base.HasName, model_base.HasDisplayName,
+                    model_base.HasTenantName,
                     model_base.AttributeMixin):
     """DB model for EndpointGroup."""
 
     __tablename__ = 'aim_endpoint_groups'
     __table_args__ = (
-        sa.ForeignKeyConstraint(
+        uniq_column(__tablename__, 'tenant_name', 'app_profile_name', 'name') +
+        (sa.ForeignKeyConstraint(
             ['tenant_name', 'app_profile_name'],
             ['aim_app_profiles.tenant_name', 'aim_app_profiles.name'],
-            name='fk_app_profile'),
-        model_base.Base.__table_args__)
+            name='fk_app_profile'),) +
+        to_tuple(model_base.Base.__table_args__))
 
-    app_profile_name = model_base.name_column(primary_key=True)
+    app_profile_name = model_base.name_column(nullable=False)
+
     bd_name = model_base.name_column()
     bd_tenant_name = model_base.name_column()
-    # TODO(amitbose) Map contract names
+
+    contracts = orm.relationship(EndpointGroupContract,
+                                 backref='epg',
+                                 cascade='all, delete-orphan',
+                                 lazy='joined')
+
+    def from_attr(self, session, res_attr):
+        self.contracts = []
+        for c in (res_attr.pop('provided_contract_names', []) or []):
+            self.contracts.append(EndpointGroupContract(name=c,
+                                                        provides=True))
+        for c in (res_attr.pop('consumed_contract_names', []) or []):
+            self.contracts.append(EndpointGroupContract(name=c,
+                                                        provides=False))
+        # map remaining attributes to model
+        super(EndpointGroup, self).from_attr(session, res_attr)
+
+    def to_attr(self, session):
+        res_attr = super(EndpointGroup, self).to_attr(session)
+        for c in res_attr.pop('contracts', []):
+            attr = ('provided_contract_names' if c.provides
+                    else 'consumed_contract_names')
+            res_attr.setdefault(attr, []).append(c.name)
+        return res_attr


### PR DESCRIPTION
Have used an auto-increment column on the EPG table
to generate an internal ID that will be referenced
by the contracts table. This is needed for resources
that have non-scalar attributes (e.g. list of contracts).
Having an internal ID avoids having primary
keys that use many columns in the table that contains
the non-scalar values. Have updated other ACI model
classes with this internal-ID.

Signed-off-by: Amit Bose <amitbose@gmail.com>