### PR TITLE
Use external_id as the primary key for Fault objects

### DIFF
--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -143,8 +143,9 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
                                 "%s for object %s: %s" %
                                 (fault_method[method].__name__,
                                  parent.__dict__, resource.__dict__))
-                            fault_method[method](self.context, parent,
-                                                 resource)
+                            fault_method[method](self.context,
+                                                 resource=parent,
+                                                 fault=resource)
                         else:
                             LOG.debug(
                                 "%s object %s" %

--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -206,16 +206,14 @@ class AimManager(object):
                 fault.status_id = status.id
                 self.create(context, fault, overwrite=True)
 
-    def clear_fault(self, context, resource, fault):
+    def clear_fault(self, context, fault, **kwargs):
         with context.db_session.begin(subtransactions=True):
-            status = self.get_status(context, resource)
-            if status:
-                db_fault = self._query_db(
-                    context.db_session, api_status.AciFault,
-                    status_id=status.id, fault_code=fault.fault_code).first()
-                if db_fault:
-                    context.db_session.delete(db_fault)
-                    self._add_commit_hook(context.db_session)
+            db_fault = self._query_db(
+                context.db_session, api_status.AciFault,
+                external_identifier=fault.external_identifier).first()
+            if db_fault:
+                context.db_session.delete(db_fault)
+                self._add_commit_hook(context.db_session)
 
     def register_update_listener(self, func):
         """Register callback for update to AIM objects.

--- a/aim/db/migration/alembic_migrations/versions/faade1155a0a_status_model.py
+++ b/aim/db/migration/alembic_migrations/versions/faade1155a0a_status_model.py
@@ -49,7 +49,6 @@ def upgrade():
 
     op.create_table(
         'aim_faults',
-        sa.Column('id', sa.String(36), primary_key=True),
         sa.Column('status_id', sa.String(length=36), nullable=False),
         sa.Column('fault_code', sa.String(25), nullable=False),
         sa.Column('severity', sa.String(25), nullable=False),
@@ -57,17 +56,12 @@ def upgrade():
         sa.Column('cause', sa.String(255), default=''),
         sa.Column('last_update_timestamp', sa.TIMESTAMP,
                   server_default=func.now(), onupdate=func.now()),
-        sa.Column('external_identifier', sa.String(255), nullable=False),
-        sa.PrimaryKeyConstraint('id'),
+        sa.Column('external_identifier', sa.String(255), primary_key=True),
+        sa.PrimaryKeyConstraint('external_identifier'),
         sa.ForeignKeyConstraint(['status_id'],
                                 ['aim_statuses.id'],
                                 ondelete='CASCADE'),
-        sa.UniqueConstraint('external_identifier',
-                            name='uniq_aim_faults_ext_id'),
-        sa.UniqueConstraint('status_id', 'fault_code',
-                            name='uniq_aim_faults_identity'),
-        sa.Index('idx_aim_faults_ext_id', 'external_identifier'),
-        sa.Index('idx_aim_faults_identity', 'status_id', 'fault_code'))
+        sa.Index('idx_aim_faults_status_id', 'status_id'))
 
 
 def downgrade():

--- a/aim/db/status_model.py
+++ b/aim/db/status_model.py
@@ -25,12 +25,9 @@ from aim.db import models
 LOG = logging.getLogger(__name__)
 
 
-class Fault(model_base.Base, model_base.HasId, model_base.AttributeMixin):
+class Fault(model_base.Base, model_base.AttributeMixin):
     __tablename__ = 'aim_faults'
-    __table_args__ = (models.uniq_column(__tablename__, 'status_id',
-                                         'fault_code') +
-                      models.uniq_column(__tablename__, 'external_identifier',
-                                         name='aim_faults_ext_id') +
+    __table_args__ = ((sa.Index('idx_aim_faults_status_id', 'status_id'), ) +
                       models.to_tuple(model_base.Base.__table_args__))
     status_id = sa.Column(sa.String(36), sa.ForeignKey('aim_statuses.id',
                                                        ondelete='CASCADE'),
@@ -43,7 +40,8 @@ class Fault(model_base.Base, model_base.HasId, model_base.AttributeMixin):
                                       onupdate=func.now())
     # external_identifier is an ID used by external entities to easily
     # correlate the fault to the proper external object
-    external_identifier = sa.Column(sa.String(255), nullable=False)
+    external_identifier = sa.Column(sa.String(255), nullable=False,
+                                    primary_key=True)
 
 
 class Status(model_base.Base, model_base.HasId, model_base.AttributeMixin):
@@ -63,4 +61,4 @@ class Status(model_base.Base, model_base.HasId, model_base.AttributeMixin):
 
     def get_faults(self, session):
         # Only return the faults' identifier
-        return [getattr(x, 'id') for x in self.faults or []]
+        return [getattr(x, 'external_identifier') for x in self.faults or []]

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -264,7 +264,16 @@ class TestResourceOpsBase(object):
         new_timestamp = status.faults[0].last_update_timestamp
         self.assertTrue(new_timestamp > timestamp)
 
-        self.mgr.clear_fault(self.ctx, res, fault)
+        # Add fault with same code
+        fault_2 = aim_status.AciFault(
+            fault_code='412', external_identifier='dn-2',
+            severity=aim_status.AciFault.SEV_CRITICAL)
+        self.mgr.set_fault(self.ctx, res, fault_2)
+        status = self.mgr.get_status(self.ctx, res)
+        self.assertEqual(2, len(status.faults))
+
+        self.mgr.clear_fault(self.ctx, fault)
+        self.mgr.clear_fault(self.ctx, fault_2)
         status = self.mgr.get_status(self.ctx, res)
         self.assertEqual(0, len(status.faults))
 


### PR DESCRIPTION
closes noironetworks/support#232