### PR TITLE
Fix unwanted contract-relationship deletion

### DIFF
--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -138,13 +138,20 @@ class EndpointGroup(model_base.Base, model_base.HasAimId,
                                  lazy='joined')
 
     def from_attr(self, session, res_attr):
-        self.contracts = []
-        for c in (res_attr.pop('provided_contract_names', []) or []):
-            self.contracts.append(EndpointGroupContract(name=c,
-                                                        provides=True))
-        for c in (res_attr.pop('consumed_contract_names', []) or []):
-            self.contracts.append(EndpointGroupContract(name=c,
-                                                        provides=False))
+        provided = [c for c in self.contracts if c.provides]
+        consumed = [c for c in self.contracts if not c.provides]
+
+        if 'provided_contract_names' in res_attr:
+            provided = []
+            for c in (res_attr.pop('provided_contract_names', []) or []):
+                provided.append(EndpointGroupContract(name=c,
+                                                      provides=True))
+        if 'consumed_contract_names' in res_attr:
+            consumed = []
+            for c in (res_attr.pop('consumed_contract_names', []) or []):
+                consumed.append(EndpointGroupContract(name=c,
+                                                      provides=False))
+        self.contracts = provided + consumed
         # map remaining attributes to model
         super(EndpointGroup, self).from_attr(session, res_attr)
 

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -446,3 +446,24 @@ class TestEndpointGroup(TestAciResourceOpsBase, base.TestAimDBBase):
                               'provided_contract_names': ['c2', 'k', 'p1'],
                               'consumed_contract_names': ['c1', 'k', 'p2']}
     test_dn = 'uni/tn-tenant1/ap-lab/epg-web'
+
+    def test_update_other_attributes(self):
+        self._create_prerequisite_objects()
+
+        res = resource.EndpointGroup(**self.test_required_attributes)
+        r0 = self.mgr.create(self.ctx, res)
+        self.assertEqual(['k', 'p1', 'p2'],
+                         getattr_canonical(r0, 'provided_contract_names'))
+
+        r1 = self.mgr.update(self.ctx, res, bd_name='net1')
+        self.assertEqual('net1', r1.bd_name)
+        self.assertEqual(['k', 'p1', 'p2'],
+                         getattr_canonical(r1, 'provided_contract_names'))
+        self.assertEqual(['c1', 'c2', 'k'],
+                         getattr_canonical(r1, 'consumed_contract_names'))
+
+        r2 = self.mgr.update(self.ctx, res, provided_contract_names=[])
+        self.assertEqual('net1', r2.bd_name)
+        self.assertEqual([], getattr_canonical(r2, 'provided_contract_names'))
+        self.assertEqual(['c1', 'c2', 'k'],
+                         getattr_canonical(r2, 'consumed_contract_names'))


### PR DESCRIPTION
Updating ordinary attributes of an EPG was clearing
out all contract provided/consumed relationships
of the EPG because the resource-to-model conversion
function was eagerly resetting contracts.

Closes noironetworks/support#235

Signed-off-by: Amit Bose <amitbose@gmail.com>