### PR TITLE
Fix AciStatus.is_error()

### DIFF
--- a/aim/api/status.py
+++ b/aim/api/status.py
@@ -76,7 +76,7 @@ class AciStatus(resource.ResourceBase, OperationalResource):
     def is_error(self):
         return (self.sync_status == self.SYNC_FAILED or
                 self.health_level == self.HEALTH_POOR or
-                [f for f in self.faults if f.severity > AciFault.SEV_MINOR])
+                [f for f in self.faults if f.is_error()])
 
 
 class AciFault(resource.ResourceBase, OperationalResource):
@@ -109,3 +109,6 @@ class AciFault(resource.ResourceBase, OperationalResource):
             {'severity': self.SEV_INFO, 'lifecycle_status': self.LC_UNKNOWN,
              'cause': '', 'description': "",
              'last_update_timestamp': None}, **kwargs)
+
+    def is_error(self):
+        return self.severity in [self.SEV_MAJOR, self.SEV_CRITICAL]

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -250,6 +250,7 @@ class TestResourceOpsBase(object):
         self.assertEqual(1, len(status.faults))
         self.assertEqual(aim_status.AciFault.SEV_CRITICAL,
                          status.faults[0].severity)
+        self.assertTrue(status.is_error())
         timestamp = status.faults[0].last_update_timestamp
         self.assertIsNotNone(timestamp)
 
@@ -263,14 +264,16 @@ class TestResourceOpsBase(object):
                          status.faults[0].severity)
         new_timestamp = status.faults[0].last_update_timestamp
         self.assertTrue(new_timestamp > timestamp)
+        self.assertFalse(status.is_error())
 
         # Add fault with same code
         fault_2 = aim_status.AciFault(
             fault_code='412', external_identifier='dn-2',
-            severity=aim_status.AciFault.SEV_CRITICAL)
+            severity=aim_status.AciFault.SEV_MAJOR)
         self.mgr.set_fault(self.ctx, res, fault_2)
         status = self.mgr.get_status(self.ctx, res)
         self.assertEqual(2, len(status.faults))
+        self.assertTrue(status.is_error())
 
         self.mgr.clear_fault(self.ctx, fault)
         self.mgr.clear_fault(self.ctx, fault_2)


### PR DESCRIPTION
Fault severity was recently changed from integer
to a string, but its use in is_error() was not
updated.

Signed-off-by: Amit Bose <amitbose@gmail.com>