### PR TITLE
Add converter rules for contracts

### DIFF
--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -137,7 +137,13 @@ class AciTenantManager(gevent.Greenlet):
         self.aci_session = apic_session
         self.dn_manager = apic_client.DNManager()
         self.tenant_name = tenant_name
-        self.tenant = Tenant(self.tenant_name, filtered_children=CHILDREN_LIST)
+        children_mos = set()
+        for mo in CHILDREN_LIST:
+            if mo in apic_client.ManagedObjectClass.supported_mos:
+                children_mos.add(apic_client.ManagedObjectClass(mo).klass_name)
+            else:
+                children_mos.add(mo)
+        self.tenant = Tenant(self.tenant_name, filtered_children=children_mos)
         self._state = structured_tree.StructuredHashTree()
         self._operational_state = structured_tree.StructuredHashTree()
         self.health_state = False
@@ -272,6 +278,22 @@ class AciTenantManager(gevent.Greenlet):
         # TODO(ivar): improve performance by squashing similar events
         self.object_backlog.put(resources)
 
+    def _decompose_dn_guess(self, dn, mo_type_hint):
+        decompose = self.dn_manager.aci_decompose_with_type
+        MO = apic_client.ManagedObjectClass
+        try:
+            return mo_type_hint, decompose(dn, mo_type_hint)
+        except apic_client.DNManager.InvalidNameFormat:
+            # check if DN fits another MO
+            other_mos = [m for m in MO.supported_mos
+                         if MO(m).klass_name == mo_type_hint]
+            for mo in other_mos:
+                try:
+                    return mo, decompose(dn, mo)
+                except apic_client.DNManager.InvalidNameFormat:
+                    pass
+        raise apic_client.DNManager.InvalidNameFormat()
+
     def _push_aim_resources(self):
         while not self.object_backlog.empty():
             request = self.object_backlog.get()
@@ -296,21 +318,24 @@ class AciTenantManager(gevent.Greenlet):
                             dn += '/tag-%s' % self.tag_name
                             tags.append({"tagInst__%s" % obj.keys()[0]:
                                          {"attributes": {"dn": dn}}})
-                    LOG.debug("Pushing into APIC: %s" % (to_push + tags))
+                    LOG.debug("Pushing %s into APIC: %s" %
+                              (method, to_push + tags))
                     # Multiple objects could result from a conversion, push
                     # them in a single transaction
+                    MO = apic_client.ManagedObjectClass
                     try:
                         with self.aci_session.transaction() as trs:
                             for obj in to_push + tags:
-                                getattr(
-                                    getattr(self.aci_session, obj.keys()[0]),
-                                    method)(
-                                    *self.dn_manager.aci_decompose(
-                                        obj.values()[0]['attributes'].pop(
-                                            'dn'),
-                                        obj.keys()[0]),
-                                    transaction=trs,
-                                    **obj.values()[0]['attributes'])
+                                attr = obj.values()[0]['attributes']
+                                mo, parents_rns = self._decompose_dn_guess(
+                                    attr.pop('dn'), obj.keys()[0])
+                                # exclude RNs that are fixed
+                                rns = [mr[1] for mr in parents_rns
+                                       if (mr[0] not in MO.supported_mos or
+                                           MO(mr[0]).rn_param_count)]
+                                getattr(getattr(self.aci_session, mo),
+                                        method)(
+                                            *rns, transaction=trs, **attr)
                     except apic_exc.ApicResponseNotOk:
                         # TODO(ivar): Either creation or deletion failed.
                         # Look at the reason and update the AIM status

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -17,6 +17,7 @@ import logging      # noqa
 import os
 
 from oslo_config import cfg
+from oslo_log import log as o_log
 from oslotest import base
 from sqlalchemy.orm import sessionmaker as sa_sessionmaker
 
@@ -66,6 +67,7 @@ class BaseTestCase(base.BaseTestCase):
             CONF(args=args, project='aim')
         else:
             conf(args)
+        o_log.setup(cfg.CONF, 'aim')
 
     def setUp(self):
         super(BaseTestCase, self).setUp()

--- a/aim/tests/etc/aim.conf.test
+++ b/aim/tests/etc/aim.conf.test
@@ -1,3 +1,6 @@
+[DEFAULT]
+#debug = True
+
 [database]
 connection = 'sqlite://'
 

--- a/aim/tests/unit/test_structured_hash_tree.py
+++ b/aim/tests/unit/test_structured_hash_tree.py
@@ -706,6 +706,29 @@ class TestAimHashTreeMaker(base.TestAimDBBase):
         exp_tree = exp_tree.add(('fvTenant|t1', 'fvBD|bd2'), **fvBD_attr)
         self.assertEqual(exp_tree, htree)
 
+    def test_update_1(self):
+        htree = tree.StructuredHashTree()
+        exp_tree = tree.StructuredHashTree()
+
+        subj = resource.ContractSubject(tenant_name='t1', contract_name='c1',
+                                        name='s1', in_filters=['i1'],
+                                        out_filters=['o1'], bi_filters=['f1'])
+        self.maker.update(htree, [subj])
+
+        exp_tree = exp_tree.add(('fvTenant|t1', 'vzBrCP|c1', 'vzSubj|s1'))
+        exp_tree = exp_tree.add(
+            ('fvTenant|t1', 'vzBrCP|c1', 'vzSubj|s1',
+             'vzInTerm|intmnl', 'vzRsFiltAtt|i1'),
+            tnVzFilterName='i1')
+        exp_tree = exp_tree.add(
+            ('fvTenant|t1', 'vzBrCP|c1', 'vzSubj|s1',
+             'vzOutTerm|outtmnl', 'vzRsFiltAtt|o1'),
+            tnVzFilterName='o1')
+        exp_tree = exp_tree.add(
+            ('fvTenant|t1', 'vzBrCP|c1', 'vzSubj|s1', 'vzRsSubjFiltAtt|f1'),
+            tnVzFilterName='f1')
+        self.assertEqual(exp_tree, htree)
+
     def test_delete(self):
         bd1 = self._get_example_aim_bd(tenant_name='t1', name='bd1')
         bd2 = self._get_example_aim_bd(tenant_name='t1', name='bd2')

--- a/aim/tools/cli/debug/hashtree.py
+++ b/aim/tools/cli/debug/hashtree.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import click
+import json
+
+from aim.common.hashtree import exceptions as h_exc
+from aim import context
+from aim.db import api
+from aim.db import tree_model
+from aim.tools.cli.groups import aimcli
+
+
+@aimcli.aim.group(name='hashtree')
+@click.pass_context
+def hashtree(ctx):
+    session = api.get_session(expire_on_commit=True)
+    aim_ctx = context.AimContext(db_session=session)
+    tenant_tree_mgr = tree_model.TenantHashTreeManager()
+    ctx.obj['tenant_tree_mgr'] = tenant_tree_mgr
+    ctx.obj['aim_ctx'] = aim_ctx
+
+
+@hashtree.command(name='dump')
+@click.option('--tenant', '-t')
+@click.pass_context
+def dump(ctx, tenant):
+    tenant_tree_mgr = ctx.obj['tenant_tree_mgr']
+    aim_ctx = ctx.obj['aim_ctx']
+    tenants = [tenant] if tenant else tenant_tree_mgr.get_tenants(aim_ctx)
+    for t in tenants:
+        try:
+            tree = tenant_tree_mgr.get(aim_ctx, t)
+            click.echo('Tenant: %s' % t)
+            click.echo(json.dumps(tree.root.to_dict(), indent=2))
+        except h_exc.HashTreeNotFound:
+            click.echo('Tree not found for tenant %s' % t)


### PR DESCRIPTION
For the most part these rules are pretty straight-forward
except for handling of in/out filters in subjects. The
AIM-to-ACI converter translates these to pseudo ACI MOs like
vzRsFiltAtt__In/vzRsFiltAtt__Out, but the hash-tree nodes
have the correct ACI MOs (vzSubj -> vzInTerm -> vzRsFiltAtt,
vzSubj -> vzOutTerm -> vzRsFiltAtt).
A few small changes were needed to ACI universe code to
handle the use-cases presented by vzInTerm/vzOutTerm.

Signed-off-by: Amit Bose <amitbose@gmail.com>