### PR TITLE
AIM resource for endpoints

### DIFF
--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -62,7 +62,8 @@ class AimManager(object):
                      api_res.Contract: models.Contract,
                      api_res.ContractSubject: models.ContractSubject,
                      api_status.AciStatus: status_model.Status,
-                     api_status.AciFault: status_model.Fault}
+                     api_status.AciFault: status_model.Fault,
+                     api_res.Endpoint: models.Endpoint}
 
     def __init__(self):
         # TODO(amitbose): initialize anything we need, for example DB stuff

--- a/aim/db/migration/alembic_migrations/versions/74f15b6aee51_endpoint.py
+++ b/aim/db/migration/alembic_migrations/versions/74f15b6aee51_endpoint.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Create endpoint table
+
+Revision ID: 74f15b6aee51
+Revises: 3ef7607a41b0
+Create Date: 2016-07-22 17:05:31.709885
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '74f15b6aee51'
+down_revision = '3ef7607a41b0'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'aim_endpoints',
+        sa.Column('uuid', sa.String(36), primary_key=True),
+        sa.Column('display_name', sa.String(256)),
+        sa.Column('epg_tenant_name', sa.String(64)),
+        sa.Column('epg_app_profile_name', sa.String(64)),
+        sa.Column('epg_name', sa.String(64)),
+        sa.PrimaryKeyConstraint('uuid'),
+        sa.ForeignKeyConstraint(
+            ['epg_tenant_name', 'epg_app_profile_name', 'epg_name'],
+            ['aim_endpoint_groups.tenant_name',
+             'aim_endpoint_groups.app_profile_name',
+             'aim_endpoint_groups.name'],
+            name='fk_epg'))
+
+
+def downgrade():
+    pass

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -280,3 +280,23 @@ class ContractSubject(model_base.Base, model_base.HasAimId,
                 attr = 'bi_filters'
             res_attr.setdefault(attr, []).append(f.name)
         return res_attr
+
+
+class Endpoint(model_base.Base, model_base.HasDisplayName,
+               model_base.AttributeMixin):
+    """DB model for Endpoint."""
+
+    __tablename__ = 'aim_endpoints'
+    __table_args__ = (
+        (sa.ForeignKeyConstraint(
+            ['epg_tenant_name', 'epg_app_profile_name', 'epg_name'],
+            ['aim_endpoint_groups.tenant_name',
+             'aim_endpoint_groups.app_profile_name',
+             'aim_endpoint_groups.name'],
+            name='fk_epg'),) +
+        to_tuple(model_base.Base.__table_args__))
+
+    uuid = sa.Column(sa.String(36), primary_key=True)
+    epg_tenant_name = model_base.name_column()
+    epg_app_profile_name = model_base.name_column()
+    epg_name = model_base.name_column()

--- a/aim/exceptions.py
+++ b/aim/exceptions.py
@@ -46,4 +46,8 @@ class UnknownResourceType(AimException):
 
 class AciResourceDefinitionError(AimException):
     message = ("Required class attribute %(attr)s not defined for "
-               "resource %(klass)s")
+               "resource %(klass)s.")
+
+
+class InvalidDNForAciResource(AimException):
+    message = ("DN %(dn)s is not valid for resource %(cls)s.")


### PR DESCRIPTION
Adding a simple resource object for endpoints
which mainly stores endpoint association to EPG.

Also added a utility function from_dn() to
construct an AIM resource from a DN string.

Signed-off-by: Amit Bose <amitbose@gmail.com>