### PR TITLE
Fixes for faults reported for filter relations

### DIFF
--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -164,15 +164,12 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
     def _retrieve_fault_parent(self, fault):
         external = fault.external_identifier
         # external is the DN of the ACI resource
-        decomposed = apic_client.DNManager().aci_decompose_with_type(
-            external, ACI_FAULT)[:-1]
+        dn_mgr = apic_client.DNManager()
+        # this will be enough in order to get the parent
+        decomposed = dn_mgr.aci_decompose_with_type(external, ACI_FAULT)[:-1]
         aci_parent = {
             decomposed[-1][0]: {
-                'attributes': {
-                    'dn': apic_client.ManagedObjectClass(
-                        decomposed[-1][0]).dn(
-                        *[x[1] for x in decomposed])}}}
-        # this will be enough in order to get the parent
+                'attributes': {'dn': dn_mgr.build(decomposed)}}}
         return self._converter.convert([aci_parent])[0]
 
 

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -185,13 +185,44 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         self.assertEqual(fault, result[0])
 
     def test_get_resources(self):
-        fault = self._get_example_aci_fault()
-        bd = self._get_example_aci_bd()
-        self._add_server_data([fault, bd], self.universe)
+        objs = [
+            self._get_example_aci_fault(),
+            self._get_example_aci_bd(),
+            {'vzRsSubjFiltAtt': {'attributes': {
+                'dn': 'uni/tn-t1/brc-c/subj-s/rssubjFiltAtt-f'}}},
+            {'vzRsFiltAtt': {'attributes': {
+                'dn': 'uni/tn-t1/brc-c/subj-s/intmnl/rsfiltAtt-g'}}},
+            {'vzRsFiltAtt': {'attributes': {
+                'dn': 'uni/tn-t1/brc-c/subj-s/outtmnl/rsfiltAtt-h'}}}]
+        self._add_server_data(objs, self.universe)
         keys = [('fvTenant|t1', 'fvAp|a1', 'fvAEPg|test', 'faultInst|951'),
-                ('fvTenant|test-tenant', 'fvBD|test')]
+                ('fvTenant|test-tenant', 'fvBD|test'),
+                ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s', 'vzRsSubjFiltAtt|f'),
+                ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s',
+                 'vzInTerm|intmnl', 'vzRsFiltAtt|g'),
+                ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s',
+                 'vzOutTerm|outtmnl', 'vzRsFiltAtt|h'), ]
         result = self.universe.get_resources(keys)
-        self.assertEqual(sorted([bd, fault]), sorted(result))
+        self.assertEqual(sorted(objs), sorted(result))
+
+    def test_get_resources_for_delete(self):
+        objs = [
+            {'fvBD': {'attributes': {
+                'dn': 'uni/tn-t1/BD-test'}}},
+            {'vzRsSubjFiltAtt': {'attributes': {
+                'dn': 'uni/tn-t1/brc-c/subj-s/rssubjFiltAtt-f'}}},
+            {'vzRsFiltAtt': {'attributes': {
+                'dn': 'uni/tn-t1/brc-c/subj-s/intmnl/rsfiltAtt-g'}}},
+            {'vzRsFiltAtt': {'attributes': {
+                'dn': 'uni/tn-t1/brc-c/subj-s/outtmnl/rsfiltAtt-h'}}}]
+        keys = [('fvTenant|t1', 'fvBD|test'),
+                ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s', 'vzRsSubjFiltAtt|f'),
+                ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s',
+                 'vzInTerm|intmnl', 'vzRsFiltAtt|g'),
+                ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s',
+                 'vzOutTerm|outtmnl', 'vzRsFiltAtt|h'), ]
+        result = self.universe.get_resources_for_delete(keys)
+        self.assertEqual(sorted(objs), sorted(result))
 
 
 class TestAciUniverse(TestAciUniverseMixin, base.TestAimDBBase):


### PR DESCRIPTION
Faults reported for subject-to-filter relations
were either ignored completely or raising exceptions
in AID. This change fixes fault reporting for
such cases where the fault parent in ambiguous by
using newly added utility methods in apicapi
DNManager.

Signed-off-by: Amit Bose <amitbose@gmail.com>