### PR TITLE
Retrieve children from events

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -216,7 +216,8 @@ def fv_rs_dom_att_converter(object_dict, otype, helper,
             dn = default_identity_converter(
                 object_dict, otype, helper, extra_attributes=[phys_dn],
                 aci_mo_type='fvRsDomAtt', to_aim=False)[0]
-            result.append({'fvRsDomAtt': {'attributes': {'dn': dn}}})
+            result.append({'fvRsDomAtt': {'attributes': {'dn': dn,
+                                                         'tDn': phys_dn}}})
         # Convert OpenStack VMMs
         for vmm in object_dict['openstack_vmm_domain_names']:
             # Get VMM DN
@@ -228,7 +229,8 @@ def fv_rs_dom_att_converter(object_dict, otype, helper,
             dn = default_identity_converter(
                 object_dict, otype, helper, extra_attributes=[vmm_dn],
                 aci_mo_type='fvRsDomAtt', to_aim=False)[0]
-            result.append({'fvRsDomAtt': {'attributes': {'dn': dn}}})
+            result.append({'fvRsDomAtt': {'attributes': {'dn': dn,
+                                                         'tDn': vmm_dn}}})
     return result
 
 

--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -83,6 +83,9 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
         return self._get_state()
 
     def get_resources(self, resource_keys):
+        if resource_keys:
+            LOG.debug("Requesting resource keys in AIM Universe: %s",
+                      resource_keys)
         result = []
         id_set = set()
         for key in resource_keys:
@@ -118,7 +121,9 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
                     LOG.warn("Resource %s is not defined in AIM", dissected)
                     result.append(res)
                     id_set.add(id_tuple)
-
+        if resource_keys:
+            LOG.debug("Result for keys %s in AIM Universe: %s" %
+                      (resource_keys, result))
         return list(result)
 
     def get_resources_for_delete(self, resource_keys):

--- a/aim/config.py
+++ b/aim/config.py
@@ -62,6 +62,9 @@ agent_opts = [
     cfg.BoolOpt('poll_config', default=False,
                 help=("Check whether to run the configuration poller or "
                       "not.")),
+    cfg.StrOpt('aim_system_id', required=True,
+               help="Identifier of the AIM system used to mark object "
+                    "ownership in ACI"),
 ]
 
 cfg.CONF.register_opts(agent_opts, 'aim')

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -111,6 +111,7 @@ class TestAimDBBase(BaseTestCase):
         # log results of queries, change INFO to DEBUG
         #
         # logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
+        self.sys_id = self.cfg_manager.get_option('aim_system_id', 'aim')
 
         def clear_tables():
             with self.engine.begin() as conn:

--- a/aim/tests/etc/aim.conf.test
+++ b/aim/tests/etc/aim.conf.test
@@ -1,5 +1,6 @@
 [DEFAULT]
 #debug = True
+apic_system_id = openstack_aid
 
 [database]
 connection = 'sqlite://'
@@ -23,6 +24,7 @@ scope_names = False
 
 [aim]
 poll_config = False
+aim_system_id = openstack_aid
 
 [apic_physdom:phys]
 

--- a/aim/tests/etc/aim.conf.test.2
+++ b/aim/tests/etc/aim.conf.test.2
@@ -20,3 +20,4 @@ scope_names = False
 
 [aim]
 poll_config = False
+aim_system_id = openstack_aid

--- a/aim/tests/etc/aim.conf.test.empty
+++ b/aim/tests/etc/aim.conf.test.empty
@@ -1,2 +1,5 @@
 [database]
 connection = 'sqlite://'
+
+[aim]
+aim_system_id = openstack_aid

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -892,15 +892,18 @@ class TestAimToAciConverterEPG(TestAimToAciConverterBase, base.TestAimDBBase):
             'fvRsDomAtt': {
                 'attributes': {
                     'dn': 'uni/tn-t1/ap-a1/epg-test-1/'
-                          'rsdomAtt-[uni/phys-phys]', }}}, {
+                          'rsdomAtt-[uni/phys-phys]',
+                    'tDn': 'uni/phys-phys'}}}, {
             'fvRsDomAtt': {
                 'attributes': {
                     'dn': 'uni/tn-t1/ap-a1/epg-test-1/'
-                          'rsdomAtt-[uni/vmmp-OpenStack/dom-op]', }}}, {
+                          'rsdomAtt-[uni/vmmp-OpenStack/dom-op]',
+                    'tDn': 'uni/vmmp-OpenStack/dom-op'}}}, {
             'fvRsDomAtt': {
                 'attributes': {
                     'dn': 'uni/tn-t1/ap-a1/epg-test-1/'
-                          'rsdomAtt-[uni/vmmp-OpenStack/dom-op2]', }}}]]
+                          'rsdomAtt-[uni/vmmp-OpenStack/dom-op2]',
+                    'tDn': 'uni/vmmp-OpenStack/dom-op2'}}}]]
     missing_ref_input = base.TestAimDBBase._get_example_aim_epg(bd_name=None)
     missing_ref_output = [{
         "fvAEPg": {"attributes": {"dn": "uni/tn-t1/ap-a1/epg-test", }}}]

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -292,6 +292,22 @@ class TestResourceOpsBase(object):
         status = self.mgr.get_status(self.ctx, res)
         self.assertEqual(0, len(status.faults))
 
+        # Delete resource and verify that status is deleted as well
+        self.mgr.set_fault(self.ctx, res, fault_2)
+        db_res = self.mgr._query_db_obj(self.ctx.db_session, res)
+        try:
+            aim_id = db_res.aim_id
+        except AttributeError:
+            # Resource doesn't support Status
+            pass
+        else:
+            self.mgr.delete(self.ctx, res)
+            status_db = self.mgr._query_db_obj(
+                self.ctx.db_session,
+                aim_status.AciStatus(resource_type=type(res).__name__,
+                                     resource_id=aim_id))
+            self.assertIsNone(status_db)
+
     def _create_prerequisite_objects(self):
         for obj in (self.prereq_objects or []):
             self.mgr.create(self.ctx, obj)

--- a/aim/tools/cli/debug/manager.py
+++ b/aim/tools/cli/debug/manager.py
@@ -20,6 +20,7 @@ from tabulate import tabulate
 
 from aim import aim_manager
 from aim.api import resource
+from aim.api import status
 from aim.common import utils
 from aim import context
 from aim.db import api
@@ -78,7 +79,10 @@ def validate_attributes(klass, attributes, param_name, dn_is_valid=False):
 def create(ctx, type, attribute):
     manager = ctx.obj['manager']
     aim_ctx = ctx.obj['aim_ctx']
-    klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    try:
+        klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    except ImportError:
+        klass = importutils.import_class(status.__name__ + '.%s' % type)
     attribute = {x.split('=')[0]: x.split('=')[1] for x in attribute}
     validate_attributes(klass, attribute.keys(), '--attribute/-a')
     res = klass(**attribute)
@@ -92,7 +96,10 @@ def create(ctx, type, attribute):
 def delete(ctx, type, attribute):
     manager = ctx.obj['manager']
     aim_ctx = ctx.obj['aim_ctx']
-    klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    try:
+        klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    except ImportError:
+        klass = importutils.import_class(status.__name__ + '.%s' % type)
     attribute = {x.split('=')[0]: x.split('=')[1] for x in attribute}
     validate_attributes(klass, attribute.keys(), '--attribute/-a')
     res = klass(**attribute)
@@ -107,7 +114,10 @@ def delete(ctx, type, attribute):
 def update(ctx, type, attribute, modify):
     manager = ctx.obj['manager']
     aim_ctx = ctx.obj['aim_ctx']
-    klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    try:
+        klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    except ImportError:
+        klass = importutils.import_class(status.__name__ + '.%s' % type)
     attribute = {x.split('=')[0]: x.split('=')[1] for x in attribute}
     validate_attributes(klass, attribute.keys(), '--attribute/-a')
     modify = {x.split('=')[0]: x.split('=')[1] for x in modify}
@@ -124,7 +134,10 @@ def update(ctx, type, attribute, modify):
 def find(ctx, type, attribute, column):
     manager = ctx.obj['manager']
     aim_ctx = ctx.obj['aim_ctx']
-    klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    try:
+        klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    except ImportError:
+        klass = importutils.import_class(status.__name__ + '.%s' % type)
     column = list(column) if column else []
     validate_attributes(klass, column, '--column/-c', dn_is_valid=True)
     attribute = {x.split('=')[0]: x.split('=')[1] for x in attribute}
@@ -140,7 +153,10 @@ def find(ctx, type, attribute, column):
 def get(ctx, type, attribute):
     manager = ctx.obj['manager']
     aim_ctx = ctx.obj['aim_ctx']
-    klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    try:
+        klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    except ImportError:
+        klass = importutils.import_class(status.__name__ + '.%s' % type)
     attribute = {x.split('=')[0]: x.split('=')[1] for x in attribute}
     validate_attributes(klass, attribute.keys(), '--attribute/-a')
     res = klass(**attribute)
@@ -152,7 +168,10 @@ def get(ctx, type, attribute):
 @click.argument('type', required=True)
 @click.pass_context
 def describe(ctx, type):
-    klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    try:
+        klass = importutils.import_class(resource.__name__ + '.%s' % type)
+    except ImportError:
+        klass = importutils.import_class(status.__name__ + '.%s' % type)
     rows = [[set_type, ', '.join(getattr(klass, set_type))]
             for set_type in [
                 'identity_attributes', 'other_attributes', 'db_attributes']]

--- a/etc/aim/aim.conf
+++ b/etc/aim/aim.conf
@@ -18,3 +18,4 @@
 # agent_down_time = 75
 agent_down_time = 75
 poll_config = False
+aim_system_id = openstack_aid

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # Requirements should be kept alphabetically ordered
 
 alembic
-acitoolkit>=0.3.1
+-e git+https://github.com/datacenter/acitoolkit.git@v0.3.2#egg=acitoolkit
 Click
 gevent>=1.1.0
 oslo.concurrency


### PR DESCRIPTION
When events are received from the WS interface on a particular
APIC object, we need to retrieve all the interesting related
items in order to properly build the hash tree.
More specifically, when a RS gets modified from an APIC object,
the latter should be completely retrieved together with all its
references.