### PR TITLE
Add DN property to AciFault objects

### DIFF
--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -393,6 +393,7 @@ class AciTenantManager(gevent.Greenlet):
             resource = event.values()[0]
             res_type = event.keys()[0]
             status = resource['attributes'].get(STATUS_FIELD)
+            raw_dn = resource['attributes'].get('dn')
             if status or res_type in OPERATIONAL_LIST:
                 try:
                     # Use the parent type and DN for related objects (like RS)
@@ -439,7 +440,8 @@ class AciTenantManager(gevent.Greenlet):
                         LOG.error(e.message)
                         raise
             if not status or status == converter.DELETED_STATUS:
-                result.append(event)
+                if raw_dn not in visited:
+                    result.append(event)
         LOG.debug('Filling procedure took %s for tenant %s' %
                   (time.time() - start, self.tenant.name))
         return result

--- a/aim/api/status.py
+++ b/aim/api/status.py
@@ -112,3 +112,7 @@ class AciFault(resource.ResourceBase, OperationalResource):
 
     def is_error(self):
         return self.severity in [self.SEV_MAJOR, self.SEV_CRITICAL]
+
+    @property
+    def dn(self):
+        return self.external_identifier

--- a/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
@@ -695,3 +695,26 @@ class TestAciTenant(base.TestAimDBBase, TestAciClientMixin):
         result = self.manager._filter_ownership(events)
         self.assertEqual(set(), self.manager.tag_set)
         self.assertEqual([], result)
+
+    def test_fill_events_fault(self):
+        events = [
+            {'fvRsCtx': {
+                'attributes': {'dn': 'uni/tn-ivar-wstest/BD-test/rsctx',
+                               'tnFvCtxName': 'asasa', 'status': 'created'}}},
+            {'faultInst': {'attributes': {
+                'dn': 'uni/tn-ivar-wstest/BD-test/rsctx/fault-F0952',
+                'code': 'F0952'}}}
+        ]
+        complete = [
+            {'fvBD': {'attributes': {'dn': u'uni/tn-ivar-wstest/BD-test'}}},
+            {'faultInst': {'attributes': {
+             'dn': 'uni/tn-ivar-wstest/BD-test/rsctx/fault-F0952',
+             'ack': 'no', 'delegated': 'no',
+             'code': 'F0952', 'type': 'config'}}},
+            {'fvRsCtx': {
+                'attributes': {'dn': 'uni/tn-ivar-wstest/BD-test/rsctx',
+                               'tnFvCtxName': 'asasa'}}},
+        ]
+        self._add_server_data(complete)
+        events = self.manager._fill_events(events)
+        self.assertEqual(sorted(complete), sorted(events))


### PR DESCRIPTION
A recent patch was assuming the "dn" property to exists in every AIM resource. Add such property to AciFaults as well (that can retrieve its value by their external identifier).