### PR TITLE
Event driven AID

### DIFF
--- a/aim/agent/aid/event_handler.py
+++ b/aim/agent/aid/event_handler.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import os
+import six
+import traceback
+
+import gevent
+from gevent import queue
+from gevent import socket
+from oslo_log import log as logging
+
+
+LOG = logging.getLogger(__name__)
+EVENT_SERVE = 'serve'
+EVENT_RECONCILE = 'reconcile'
+EVENTS = [EVENT_SERVE, EVENT_RECONCILE]
+PAYLOAD_MAX_LEN = 1024
+
+
+@six.add_metaclass(abc.ABCMeta)
+class EventHandlerBase(object):
+    """Event Handler for AID."""
+
+    @abc.abstractmethod
+    def initialize(self, conf):
+        """Initialize Event Handler
+
+        :param conf
+        :return:
+        """
+
+    @abc.abstractmethod
+    def get_event(self, timeout=None):
+        """Get AID event
+
+        Blocking call, which returns AID events when present. A timeout
+        can be set.
+        :param timeout
+        :return:
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class SenderBase(object):
+    """Sender for AID events."""
+
+    @abc.abstractmethod
+    def initialize(self, conf):
+        """Initialize Sender
+
+        :param conf
+        :return:
+        """
+
+    @abc.abstractmethod
+    def serve(self):
+        """Send a serve event.
+
+        :return:
+        """
+
+    @abc.abstractmethod
+    def reconcile(self):
+        """Send a reconcile event.
+
+        :return:
+        """
+
+
+class EventHandler(EventHandlerBase):
+
+    q = None
+
+    def initialize(self, conf_manager):
+        LOG.info("Initialize Event Handler")
+        self.conf_manager = conf_manager
+        self.listener = self._spawn_listener()
+        EventHandler.q = queue.Queue()
+        gevent.sleep(0)
+        return self
+
+    def _connect(self):
+        self.us_path = self.conf_manager.get_option('unix_socket_path',
+                                                    group='aim')
+        LOG.info("Connect to socket %s" % self.us_path)
+        try:
+            os.unlink(self.us_path)
+        except OSError:
+            if os.path.exists(self.us_path):
+                raise
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        self.sock.bind(self.us_path)
+
+    def _spawn_listener(self):
+        return gevent.spawn(self._listener)
+
+    def _listener(self):
+        # Multiple event notifiers can connect to AID
+        while True:
+            try:
+                self._connect()
+                LOG.info("Listening for Events on %s", self.us_path)
+                while True:
+                    self._recv_loop()
+            except gevent.GreenletExit:
+                LOG.warn("Killed event listener thread")
+                return
+            except Exception as e:
+                LOG.debug(traceback.format_exc())
+                LOG.error("An error as occurred in the event listener "
+                          "thread: %s" % e.message)
+                # TODO(ivar): exponentially backoff before reconnecting
+                gevent.sleep(2)
+            finally:
+                try:
+                    self.sock.close()
+                except AttributeError:
+                    LOG.debug("Socket wasn't initialized before failure")
+
+    def _recv_loop(self):
+        event = self.sock.recv(PAYLOAD_MAX_LEN)
+        LOG.debug("Received event %s" % event)
+        if event.lower() in EVENTS:
+            self._put_event(event)
+
+    def get_event(self, timeout=None):
+        try:
+            return self.q.get(timeout=timeout)
+        except queue.Empty:
+            # Timeout expired
+            return None
+
+    @staticmethod
+    def serve():
+        EventHandler._put_event(EVENT_SERVE)
+
+    @staticmethod
+    def reconcile():
+        EventHandler._put_event(EVENT_RECONCILE)
+
+    @staticmethod
+    def _put_event(event):
+        try:
+            EventHandler.q.put_nowait(event)
+        except queue.Full:
+            LOG.warn("Event queue is full, discard %s event" % event)
+        except AttributeError:
+            LOG.warn("Event queue not initialized, cannot set event")
+
+
+class EventSender(SenderBase):
+
+    def initialize(self, conf):
+        self.conf_manager = conf
+        self.us_path = self.conf_manager.get_option('unix_socket_path',
+                                                    group='aim')
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        self.sock.connect(self.us_path)
+        LOG.info("Connected to %s" % self.us_path)
+        return self
+
+    def serve(self):
+        self._send(EVENT_SERVE)
+
+    def reconcile(self):
+        self._send(EVENT_RECONCILE)
+
+    def _send(self, event):
+        LOG.debug("Sending %s event" % event)
+        try:
+            self.sock.send(event)
+        except Exception as e:
+            LOG.debug(traceback.format_exc())
+            LOG.error("An error as occurred in the event sender "
+                      "thread: %s" % e.message)
+            self.sock.close()
+            self.initialize(self.conf_manager)

--- a/aim/agent/aid/event_services/README.rst
+++ b/aim/agent/aid/event_services/README.rst
@@ -1,0 +1,1 @@
+TODO: how to write an event service

--- a/aim/agent/aid/event_services/event_service_base.py
+++ b/aim/agent/aid/event_services/event_service_base.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import signal
+import six
+import sys
+
+from oslo_log import log as logging
+
+from aim.agent.aid import event_handler
+from aim import config as aim_cfg
+from aim import context
+from aim.db import api
+
+
+LOG = logging.getLogger(__name__)
+logging.register_options(aim_cfg.CONF)
+aim_cfg.CONF.register_opts(aim_cfg.common_opts)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class EventServiceBase(object):
+
+    def __init__(self, conf):
+        self.host = conf.host
+        self.session = api.get_session()
+        self.context = context.AimContext(self.session)
+        self.conf_manager = aim_cfg.ConfigManager(self.context, self.host)
+        # TODO(ivar): heartbeat for these services?
+        self.sender = event_handler.EventSender().initialize(self.conf_manager)
+
+    @abc.abstractmethod
+    def run(self):
+        pass
+
+    def _handle_sigterm(self, signum, frame):
+        LOG.debug("Agent caught SIGTERM, quitting daemon loop.")
+        self.run_daemon_loop = False
+
+
+def main(klass):
+    aim_cfg.init(sys.argv[1:])
+    aim_cfg.setup_logging()
+    try:
+        agent = klass(aim_cfg.CONF)
+    except (RuntimeError, ValueError) as e:
+        LOG.error("%s Agent terminated!" % e)
+        sys.exit(1)
+
+    signal.signal(signal.SIGTERM, agent._handle_sigterm)
+    agent.run()

--- a/aim/agent/aid/event_services/polling.py
+++ b/aim/agent/aid/event_services/polling.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import traceback
+
+import gevent
+from oslo_log import log as logging
+
+from aim.agent.aid.event_services import event_service_base
+from aim.common import utils
+from aim import config as aim_cfg
+
+
+LOG = logging.getLogger(__name__)
+logging.register_options(aim_cfg.CONF)
+aim_cfg.CONF.register_opts(aim_cfg.common_opts)
+
+
+class Poller(event_service_base.EventServiceBase):
+
+    def __init__(self, conf):
+        super(Poller, self).__init__(conf)
+        self.loop_count = float('inf')
+        # TODO(ivar): per service config
+        self.polling_interval = self.conf_manager.get_option_and_subscribe(
+            self._change_polling_interval, 'service_polling_interval',
+            group='aim_event_service_polling')
+
+    def run(self):
+        # Serve tenants the very first time regardless of the events received
+        while self.loop_count > 0:
+            try:
+                start_time = time.time()
+                self._daemon_loop()
+                utils.wait_for_next_cycle(
+                    start_time, self.polling_interval,
+                    LOG, readable_caller='Event Service Poller',
+                    notify_exceeding_timeout=False)
+                self.loop_count -= 1
+            except Exception:
+                LOG.error('A error occurred in polling agent')
+                LOG.error(traceback.format_exc())
+                # TODO(ivar): exponentially backoff before reconnecting
+                gevent.sleep(2)
+
+    def _daemon_loop(self):
+        self.sender.serve()
+
+    def _change_polling_interval(self, new_conf):
+        # TODO(ivar): interrupt current sleep and restart with new value
+        self.polling_interval = new_conf['value']
+
+
+def main():
+    event_service_base.main(Poller)
+
+
+if __name__ == '__main__':
+    main()

--- a/aim/agent/aid/event_services/rpc.py
+++ b/aim/agent/aid/event_services/rpc.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import traceback
+
+from oslo_log import log as logging
+import oslo_messaging
+
+from aim.common import utils
+from aim import config as aim_cfg
+
+
+LOG = logging.getLogger(__name__)
+TOPIC_AID_EVENT = 'aid_event'
+
+
+class AIDEventRpcApi(object):
+    """RPC client"""
+
+    AID_RPC_VERSION = "1.0"
+
+    def __init__(self):
+        target = oslo_messaging.Target(
+            topic=TOPIC_AID_EVENT, version=self.AID_RPC_VERSION)
+        # If a transport backend is explicitly set in the config file, this
+        # module will become a proper RPC client. If not, we make sure the
+        # default is an invalid string and all the RPCs called from this
+        # class will be noop.
+        aim_cfg.cfg.set_defaults(oslo_messaging.transport._transport_opts,
+                                 rpc_backend='')
+        try:
+            transport = oslo_messaging.get_transport(aim_cfg.CONF)
+            self.client = oslo_messaging.RPCClient(transport, target)
+        except (oslo_messaging.DriverLoadFailure,
+                oslo_messaging.InvalidTransportURL) as ex:
+            LOG.debug(traceback.format_exc())
+            LOG.warn("Couldn't initialize RPC transport, this API will be a "
+                     "noop: %s" % ex.message)
+            self.client = None
+
+    @utils.log
+    def serve(self, context, server=None):
+        LOG.debug("Sending broadcast 'serve' message")
+        return self._cast(context, 'serve', server)
+
+    @utils.log
+    def reconcile(self, context, server=None):
+        LOG.debug("Sending broadcast 'reconcile' message")
+        return self._cast(context, 'reconcile', server)
+
+    def _cast(self, context, method, server):
+        if self.client:
+            if server:
+                cctxt = self.client.prepare(server=server)
+            else:
+                cctxt = self.client
+            return cctxt.cast(context, method, fanout=True)
+
+    def tree_creation_postcommit(self, session, added, updated, deleted):
+        if added or deleted:
+            self.serve({})
+        if updated:
+            self.reconcile({})
+
+
+class AIDEventServerRpcCallback(object):
+    """Server side event RPC."""
+
+    AID_RPC_VERSION = "1.0"
+    target = oslo_messaging.Target(version=AID_RPC_VERSION)
+
+    def __init__(self, sender):
+        self.sender = sender
+
+    def serve(self, context, **kwargs):
+        return self.sender.serve()
+
+    def reconcile(self, context, **kwargs):
+        return self.sender.reconcile()
+
+
+class Connection(object):
+
+    def __init__(self):
+        super(Connection, self).__init__()
+        self.servers = []
+        self.transport = oslo_messaging.get_transport(aim_cfg.CONF)
+
+    def create_consumer(self, topic, endpoints):
+        target = oslo_messaging.Target(topic=topic, server=aim_cfg.CONF.host)
+        server = oslo_messaging.get_rpc_server(self.transport, target,
+                                               endpoints, executor='eventlet')
+        self.servers.append(server)
+
+    def consume_in_threads(self):
+        for server in self.servers:
+            server.start()
+        return self.servers
+
+    def close(self):
+        for server in self.servers:
+            server.stop()
+        for server in self.servers:
+            server.wait()

--- a/aim/agent/aid/event_services/rpc_service.py
+++ b/aim/agent/aid/event_services/rpc_service.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import eventlet
+eventlet.monkey_patch()
+
+from oslo_log import log as logging
+
+from aim.agent.aid.event_services import event_service_base
+from aim.agent.aid.event_services import rpc
+from aim import config as aim_cfg
+
+
+LOG = logging.getLogger(__name__)
+logging.register_options(aim_cfg.CONF)
+aim_cfg.CONF.register_opts(aim_cfg.common_opts)
+
+
+class RpcEventService(event_service_base.EventServiceBase):
+
+    def run(self):
+        self.endpoints = [rpc.AIDEventServerRpcCallback(self.sender)]
+        self.topic = rpc.TOPIC_AID_EVENT
+        self.conn = rpc.Connection()
+        self.conn.create_consumer(self.topic, self.endpoints)
+        self.conn.consume_in_threads()
+        LOG.info("RPC Event Service initialized!")
+        while True:
+            eventlet.sleep(1)
+
+
+def main():
+    event_service_base.main(RpcEventService)
+
+
+if __name__ == '__main__':
+    main()

--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -25,6 +25,7 @@ from apicapi import exceptions as apic_exc
 import gevent
 from oslo_log import log as logging
 
+from aim.agent.aid import event_handler
 from aim.agent.aid.universes.aci import converter
 from aim.agent.aid.universes import base_universe
 from aim.common.hashtree import structured_tree
@@ -461,6 +462,7 @@ class AciTenantManager(gevent.Greenlet):
             if modified:
                 LOG.debug("New tree for tenant %s: %s" % (self.tenant_name,
                                                           str(state)))
+                event_handler.EventHandler.reconcile()
             else:
                 LOG.debug("No changes in tree for tenant %s: " %
                           self.tenant_name)

--- a/aim/common/utils.py
+++ b/aim/common/utils.py
@@ -45,16 +45,19 @@ def generate_uuid():
     return str(uuid.uuid4())
 
 
-def wait_for_next_cycle(start_time, polling_interval, log, readable_caller=''):
+def wait_for_next_cycle(start_time, polling_interval, log, readable_caller='',
+                        notify_exceeding_timeout=True):
     # sleep till end of polling interval
     elapsed = time.time() - start_time
     log.debug("%(caller)s loop - completed in %(time).3f. ",
               {'caller': readable_caller, 'time': elapsed})
     if elapsed < polling_interval:
         gevent.sleep(polling_interval - elapsed)
-    else:
+    elif notify_exceeding_timeout:
         log.debug("Loop iteration exceeded interval "
                   "(%(polling_interval)s vs. %(elapsed)s)!",
                   {'polling_interval': polling_interval,
                    'elapsed': elapsed})
+        gevent.sleep(0)
+    else:
         gevent.sleep(0)

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1076,7 +1076,8 @@ class TestAimToAciConverterL3Outside(TestAimToAciConverterBase,
                                               tenant_name='common',
                                               name='l3o2',
                                               dn='uni/tn-common/out-l3o2',
-                                              monitored=True)]
+                                              monitored=True),
+                    get_example_aim_l3outside(name='inet2')]
     sample_output = [
         [_aci_obj('l3extOut', dn='uni/tn-t1/out-inet2'),
          _aci_obj('l3extRsEctx', dn='uni/tn-t1/out-inet2/rsectx',
@@ -1086,7 +1087,13 @@ class TestAimToAciConverterL3Outside(TestAimToAciConverterBase,
                   tDn='uni/foo')],
         [_aci_obj('l3extRsEctx', dn='uni/tn-t1/out-inet1/rsectx',
                   tnFvCtxName='shared')],
-        [_aci_obj('l3extOut', dn='uni/tn-common/out-l3o2', name='l3o2')]]
+        [_aci_obj('l3extOut', dn='uni/tn-common/out-l3o2', name='l3o2')],
+        [_aci_obj('l3extOut', dn='uni/tn-t1/out-inet2'),
+         _aci_obj('l3extRsEctx', dn='uni/tn-t1/out-inet2/rsectx',
+                  tnFvCtxName=''),
+         _aci_obj('l3extRsL3DomAtt',
+                  dn='uni/tn-t1/out-inet2/rsL3DomAtt',
+                  tDn='')]]
     missing_ref_input = get_example_aim_l3outside(vrf_name=None,
                                                   l3_domain_dn=None)
     missing_ref_output = [_aci_obj('l3extOut', dn='uni/tn-t1/out-inet1')]

--- a/aim/tests/unit/agent/event_services/base.py
+++ b/aim/tests/unit/agent/event_services/base.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from aim.tests import base
+
+
+class TestEventServiceBase(base.TestAimDBBase):
+
+    def setUp(self):
+        super(TestEventServiceBase, self).setUp()
+        self.send_serve = mock.patch(
+            'aim.agent.aid.event_handler.EventSender.serve')
+        self.send_serve.start()
+        self.send_reconcile = mock.patch(
+            'aim.agent.aid.event_handler.EventSender.reconcile')
+        self.send_reconcile.start()
+        self.initialize = mock.patch(
+            'aim.agent.aid.event_handler.EventSender.initialize')
+        self.initialize.start()
+
+        self.addCleanup(self.send_serve.stop)
+        self.addCleanup(self.send_reconcile.stop)
+        self.addCleanup(self.initialize.stop)

--- a/aim/tests/unit/agent/event_services/test_polling.py
+++ b/aim/tests/unit/agent/event_services/test_polling.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from aim.agent.aid.event_services import polling
+from aim.tests.unit.agent.event_services import base
+
+
+class TestEventServicePolling(base.TestEventServiceBase):
+
+    def setUp(self):
+        super(TestEventServicePolling, self).setUp()
+        self.set_override('service_polling_interval', 0,
+                          group='aim_event_service_polling')
+
+    def test_run(self):
+        polling_service = polling.Poller(self.cfg_manager)
+        polling_service.loop_count = 1
+        polling_service.run()
+        polling_service.sender.serve.assert_called_once()

--- a/aim/tests/unit/agent/test_event_handler.py
+++ b/aim/tests/unit/agent/test_event_handler.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+
+import gevent
+import mock
+
+from aim.agent.aid import event_handler
+from aim.tests import base
+
+
+class TestEventHandler(base.TestAimDBBase):
+
+    def setUp(self):
+        super(TestEventHandler, self).setUp()
+        self.set_override('unix_socket_path', 'etc/aim/test_sock.sock',
+                          group='aim')
+        self.handler = event_handler.EventHandler().initialize(
+            self.cfg_manager)
+        gevent.sleep(0)
+        self.sender = event_handler.EventSender().initialize(self.cfg_manager)
+        gevent.sleep(0)
+        # Context switch
+        self.addCleanup(self.sender.sock.close)
+        self.addCleanup(self._unlink_socket)
+
+    def _unlink_socket(self):
+        os.unlink(self.handler.us_path)
+
+    def test_open(self):
+        self.assertFalse(self.handler.sock.closed)
+        self.assertFalse(self.sender.sock.closed)
+
+    def test_receive_event(self):
+        self.sender.serve()
+        self.assertEqual(event_handler.EVENT_SERVE, self.handler.get_event())
+
+        self.sender.reconcile()
+        self.assertEqual(event_handler.EVENT_RECONCILE,
+                         self.handler.get_event())
+
+    def test_listener_killed(self):
+        self.handler.listener.kill()
+        self.assertTrue(self.handler.listener.dead)
+
+        self.handler._recv_loop = mock.Mock(side_effect=Exception)
+        self.handler.listener = self.handler._spawn_listener()
+        gevent.sleep(0)
+        self.assertFalse(self.handler.listener.dead)
+        self.handler.listener.kill()
+
+        del self.handler.sock
+        self.handler._connect = mock.Mock(side_effect=gevent.GreenletExit)
+        self.handler.listener = self.handler._spawn_listener()
+        gevent.sleep(0)
+        self.assertTrue(self.handler.listener.dead)

--- a/aim/tests/unit/tools/cli/test_db_config.py
+++ b/aim/tests/unit/tools/cli/test_db_config.py
@@ -54,6 +54,6 @@ class TestDBConfig(base.TestShell):
         # All default values are set, can be useful for first time
         # installations
         self.assertEqual(
-            5, self.manager.get_option('agent_polling_interval', 'aim'))
+            0.0, self.manager.get_option('agent_polling_interval', 'aim'))
         self.assertEqual(
             [], self.manager.get_option('apic_hosts', 'apic'))

--- a/aim/tools/cli/debug/event_service_polling.py
+++ b/aim/tools/cli/debug/event_service_polling.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import click
+
+from aim.agent.aid.event_services import polling
+from aim.tools.cli.groups import aimcli
+
+
+@aimcli.aim.command(name='event-service-polling')
+@click.pass_context
+def event_service_polling(ctx):
+    try:
+        agent = polling.Poller(ctx.obj['conf'])
+    except (RuntimeError, ValueError) as e:
+        click.echo("%s Agent terminated!" % e)
+        return
+    agent.run()

--- a/aim/tools/cli/debug/event_service_rpc.py
+++ b/aim/tools/cli/debug/event_service_rpc.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import click
+
+from aim.agent.aid.event_services import rpc
+from aim.tools.cli.groups import aimcli
+
+
+@aimcli.aim.command(name='event-service-rpc')
+@click.pass_context
+def event_service_rpc(ctx):
+    try:
+        agent = rpc.RpcEventService(ctx.obj['conf'])
+    except (RuntimeError, ValueError) as e:
+        click.echo("%s Agent terminated!" % e)
+        return
+    agent.run()

--- a/etc/aim/aim.conf
+++ b/etc/aim/aim.conf
@@ -1,3 +1,19 @@
+[DEFAULT]
+debug=True
+apic_system_id=openstack
+rpc_backend=rabbit
+control_exchange=neutron
+default_log_levels=neutron.context=ERROR
+
+[oslo_messaging_rabbit]
+rabbit_host=<rabbit-mq-host>
+rabbit_port=<rabbit-m1-port>
+rabbit_hosts=<rabbit-mq-host>:<rabbit-m1-port>
+rabbit_use_ssl=False
+rabbit_userid=username
+rabbit_password=password
+rabbit_ha_queues=False
+
 [database]
 # Example:
 # connection = mysql://root:pass@127.0.0.1:3306/aim

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ gevent>=1.1.0
 oslo.concurrency
 oslo.config
 oslo.db
+oslo.messaging
 oslo.log
 oslo.utils
 pbr>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,5 @@ console_scripts=
     aim = aim.tools.cli.shell:run
     aim-debug = aim.tools.cli.debug_shell:run
     aim-aid = aim.agent.aid.service:main
+    aim-event-service-polling = aim.agent.aid.event_services.polling:main
+    aim-event-service-rpc = aim.agent.aid.event_services.rpc_service:main


### PR DESCRIPTION
In order to improve AID performance, we are getting rid of the
current polling mechanism in favor of a more modular and event
driven approach. The main AID service will listen on a configurable
unix domain socket, waiting for datagrams coming from external
services that will issue the following events:

- serve: modify the current tenant list and reconcile state. An
  event_service can issue this command when a tenant is added/removed
  in AIM;
- reconcile: reconcile current tenants' state.

More than one event_service can run at the same time, and even
different combinations for each AID process (although unadvised).
In this patch, the following event_services are implemented:

- polling service: Keeps today's functionality by polling the DB
  every few seconds. We should always run this service (possibly
  with a high polling time) to recover from events loss;
- rpc service: Based on oslo RPC, this event service will run a
  listener for one of the supported transports and will issue
  notifications from AIM based on after_commit hooks in the Tree
  manager. If no transport type is explicitly specified in the config
  file, AIM will not be able to send notifications (which could be
  expected in case a different event service is used).

Next in order of priority is the Postgresql event service, which will
leverage Postgresql DB remote events.