### PR TITLE
Add support for host-links

### DIFF
--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -16,10 +16,12 @@
 from oslo_log import log as logging
 from sqlalchemy import event as sa_event
 
+from aim.api import infra as api_infra
 from aim.api import resource as api_res
 from aim.api import status as api_status
 from aim.db import agent_model
 from aim.db import hashtree_db_listener as ht_db_l
+from aim.db import infra_model
 from aim.db import models
 from aim.db import status_model
 from aim import exceptions as exc
@@ -68,7 +70,8 @@ class AimManager(object):
                      api_res.PhysicalDomain: models.PhysicalDomain,
                      api_res.L3Outside: models.L3Outside,
                      api_res.ExternalNetwork: models.ExternalNetwork,
-                     api_res.ExternalSubnet: models.ExternalSubnet, }
+                     api_res.ExternalSubnet: models.ExternalSubnet,
+                     api_infra.HostLink: infra_model.HostLink}
 
     def __init__(self):
         # TODO(amitbose): initialize anything we need, for example DB stuff

--- a/aim/api/infra.py
+++ b/aim/api/infra.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from aim.api import resource
+
+
+class HostLink(resource.ResourceBase):
+    """Switch-port connection information for a host node."""
+
+    identity_attributes = ['host_name', 'interface_name']
+    other_attributes = ['interface_mac',
+                        'switch_id',
+                        'module',
+                        'port',
+                        'path']
+
+    def __init__(self, **kwargs):
+        super(HostLink, self).__init__({'interface_mac': '',
+                                        'switch_id': '',
+                                        'module': '',
+                                        'port': '',
+                                        'path': ''}, **kwargs)

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -261,6 +261,13 @@ class EndpointGroup(AciResourceBase):
 
     Identity attributes: name of ACI tenant, name of application-profile
     and name of endpoint-group.
+
+    Attribute 'static_paths' is a list of dicts with the following keys:
+    * path: (Required) path-name of the switch-port which is bound to
+            EndpointGroup
+    * encap: (Required) encapsulation mode and identifier for
+            this EndpointGroup on the specified switch-port. Must be specified
+            in the format 'vlan-<vlan-id>' for VLAN encapsulation
     """
 
     identity_attributes = ['tenant_name', 'app_profile_name', 'name']
@@ -271,6 +278,7 @@ class EndpointGroup(AciResourceBase):
                         'consumed_contract_names',
                         'openstack_vmm_domain_names',
                         'physical_domain_names',
+                        'static_paths',
                         'monitored']
 
     _aci_mo_name = 'fvAEPg'
@@ -287,6 +295,7 @@ class EndpointGroup(AciResourceBase):
                                              'physical_domain_names': [],
                                              'policy_enforcement_pref':
                                              self.POLICY_UNENFORCED,
+                                             'static_paths': [],
                                              'monitored': False},
                                             **kwargs)
 

--- a/aim/db/infra_model.py
+++ b/aim/db/infra_model.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import sqlalchemy as sa
+
+from aim.db import model_base
+
+
+class HostLink(model_base.Base, model_base.AttributeMixin):
+    __tablename__ = 'aim_host_links'
+
+    host_name = sa.Column(sa.String(256), primary_key=True)
+    interface_name = sa.Column(sa.String(64), primary_key=True)
+    interface_mac = sa.Column(sa.String(24))
+
+    switch_id = sa.Column(sa.String(128))
+    module = sa.Column(sa.String(128))
+    port = sa.Column(sa.String(128))
+    path = sa.Column(sa.String(1024))

--- a/aim/db/migration/alembic_migrations/versions/d8abdb89ba66_hostlink.py
+++ b/aim/db/migration/alembic_migrations/versions/d8abdb89ba66_hostlink.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Create table for HostLinks and EPG static-paths.
+
+Revision ID: d8abdb89ba66
+Revises: 07113feba145
+Create Date: 2016-11-30 19:02:47.560600
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd8abdb89ba66'
+down_revision = '07113feba145'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'aim_endpoint_group_static_paths',
+        sa.Column('epg_aim_id', sa.Integer, nullable=False),
+        sa.Column('path', sa.String(1024), nullable=False),
+        sa.Column('encap', sa.String(24)),
+        sa.PrimaryKeyConstraint('epg_aim_id', 'path'),
+        sa.ForeignKeyConstraint(
+            ['epg_aim_id'], ['aim_endpoint_groups.aim_id']))
+
+    op.create_table(
+        'aim_host_links',
+        sa.Column('host_name', sa.String(256), nullable=False),
+        sa.Column('interface_name', sa.String(64), nullable=False),
+        sa.Column('interface_mac', sa.String(24)),
+        sa.Column('switch_id', sa.String(128)),
+        sa.Column('module', sa.String(128)),
+        sa.Column('port', sa.String(128)),
+        sa.Column('path', sa.String(1024)),
+        sa.PrimaryKeyConstraint('host_name', 'interface_name'))
+
+
+def downgrade():
+    pass

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -289,7 +289,8 @@ class TestAciToAimConverterEPG(TestAciToAimConverterBase, base.TestAimDBBase):
          'skip': ['bdName', 'providedContractNames',
                   'consumedContractNames',
                   'openstackVmmDomainNames',
-                  'physicalDomainNames']},
+                  'physicalDomainNames',
+                  'staticPaths']},
         {'resource': 'fvRsBd',
          'exceptions': {'bd_name': {'other': 'tnFvBDName'}, },
          'to_resource': converter.default_to_resource_strict, },
@@ -301,7 +302,10 @@ class TestAciToAimConverterEPG(TestAciToAimConverterBase, base.TestAimDBBase):
          'converter': converter.fvRsCons_converter, },
         {'resource': 'fvRsDomAtt',
          'exceptions': {},
-         'converter': converter.fv_rs_dom_att_converter, }
+         'converter': converter.fv_rs_dom_att_converter, },
+        {'resource': 'fvRsPathAtt',
+         'exceptions': {},
+         'converter': converter.fv_rs_path_att_converter, }
     ]
     sample_input = [[base.TestAimDBBase._get_example_aci_epg(),
                      {'fvRsBd':
@@ -336,6 +340,16 @@ class TestAciToAimConverterEPG(TestAciToAimConverterBase, base.TestAimDBBase):
                       {'attributes':
                        {'dn': 'uni/tn-t1/ap-a1/epg-test/'
                               'rsdomAtt-[uni/vmmp-OpenStack/dom-op2]', }}},
+                     _aci_obj('fvRsPathAtt',
+                              dn='uni/tn-t1/ap-a1/epg-test/rspathAtt-'
+                                 '[topology/pod-1/paths-202/pathep-[eth1/7]]',
+                              tDn='topology/pod-1/paths-202/pathep-[eth1/7]',
+                              encap='vlan-33'),
+                     _aci_obj('fvRsPathAtt',
+                              dn='uni/tn-t1/ap-a1/epg-test/rspathAtt-'
+                                 '[topology/pod-1/paths-102/pathep-[eth1/2]]',
+                              tDn='topology/pod-1/paths-102/pathep-[eth1/2]',
+                              encap='vlan-39'),
                      ],
                     base.TestAimDBBase._get_example_aci_epg(
                         dn='uni/tn-t1/ap-a1/epg-test-1',
@@ -349,7 +363,13 @@ class TestAciToAimConverterEPG(TestAciToAimConverterBase, base.TestAimDBBase):
                                provided_contract_names=['p1', 'k'],
                                consumed_contract_names=['c1', 'k'],
                                openstack_vmm_domain_names=['op', 'op2'],
-                               physical_domain_names=['phys']),
+                               physical_domain_names=['phys'],
+                               static_paths=[{'path': 'topology/pod-1/paths'
+                                                      '-202/pathep-[eth1/7]',
+                                              'encap': 'vlan-33'},
+                                             {'path': 'topology/pod-1/paths'
+                                                      '-102/pathep-[eth1/2]',
+                                             'encap': 'vlan-39'}]),
         resource.EndpointGroup(tenant_name='t1',
                                app_profile_name='a1',
                                name='test-1',
@@ -877,7 +897,13 @@ class TestAimToAciConverterEPG(TestAimToAciConverterBase, base.TestAimDBBase):
                         provided_contract_names=['k', 'p1'],
                         consumed_contract_names=['c1', 'k'],
                         openstack_vmm_domain_names=['op', 'op2'],
-                        physical_domain_names=['phys'])]
+                        physical_domain_names=['phys'],
+                        static_paths=[{'path': 'topology/pod-1/paths-202/'
+                                               'pathep-[eth1/7]',
+                                       'encap': 'vlan-33'},
+                                      {'path': 'topology/pod-1/paths-102/'
+                                               'pathep-[eth1/2]',
+                                       'encap': 'vlan-39'}])]
     sample_output = [
         [{
             "fvAEPg": {
@@ -927,7 +953,17 @@ class TestAimToAciConverterEPG(TestAimToAciConverterBase, base.TestAimDBBase):
                 'attributes': {
                     'dn': 'uni/tn-t1/ap-a1/epg-test-1/'
                           'rsdomAtt-[uni/vmmp-OpenStack/dom-op2]',
-                    'tDn': 'uni/vmmp-OpenStack/dom-op2'}}}]]
+                    'tDn': 'uni/vmmp-OpenStack/dom-op2'}}},
+            _aci_obj('fvRsPathAtt',
+                     dn='uni/tn-t1/ap-a1/epg-test-1/rspathAtt-'
+                        '[topology/pod-1/paths-202/pathep-[eth1/7]]',
+                     tDn='topology/pod-1/paths-202/pathep-[eth1/7]',
+                     encap='vlan-33'),
+            _aci_obj('fvRsPathAtt',
+                     dn='uni/tn-t1/ap-a1/epg-test-1/rspathAtt-'
+                        '[topology/pod-1/paths-102/pathep-[eth1/2]]',
+                     tDn='topology/pod-1/paths-102/pathep-[eth1/2]',
+                     encap='vlan-39')]]
     missing_ref_input = base.TestAimDBBase._get_example_aim_epg(bd_name=None)
     missing_ref_output = [{
         "fvAEPg": {"attributes": {"dn": "uni/tn-t1/ap-a1/epg-test",

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -24,6 +24,7 @@ import mock
 import time
 
 from aim import aim_manager
+from aim.api import infra
 from aim.api import resource
 from aim.api import status as aim_status
 from aim.common.hashtree import structured_tree
@@ -539,14 +540,26 @@ class TestEndpointGroup(TestAciResourceOpsBase, base.TestAimDBBase):
                                 'name': 'web',
                                 'provided_contract_names': ['k', 'p1', 'p2'],
                                 'consumed_contract_names': ['c1', 'c2', 'k'],
-                                'openstack_vmm_domain_names': ['openstack']}
+                                'openstack_vmm_domain_names': ['openstack'],
+                                'static_paths': [{'path': 'topology/pod-1/'
+                                                          'paths-101/pathep-'
+                                                          '[eth1/2]',
+                                                  'encap': 'vlan-2'},
+                                                 {'path': 'topology/pod-1/'
+                                                          'paths-102/pathep-'
+                                                          '[eth1/5]',
+                                                  'encap': 'vlan-5'}]}
     test_search_attributes = {'name': 'web'}
     test_update_attributes = {'bd_name': 'net1',
                               'policy_enforcement_pref':
                               resource.EndpointGroup.POLICY_ENFORCED,
                               'provided_contract_names': ['c2', 'k', 'p1'],
                               'consumed_contract_names': ['c1', 'k', 'p2'],
-                              'physical_domain_names': ['phys']}
+                              'physical_domain_names': ['phys'],
+                              'static_paths': [{'path': ('topology/pod-1/'
+                                                         'paths-101/pathep-'
+                                                         '[eth1/2]'),
+                                                'encap': 'vlan-22'}]}
     test_dn = 'uni/tn-tenant1/ap-lab/epg-web'
 
     def test_update_other_attributes(self):
@@ -721,3 +734,22 @@ class TestExternalSubnet(TestAciResourceOpsBase, base.TestAimDBBase):
     test_update_attributes = {'display_name': 'home'}
     test_dn = ('uni/tn-tenant1/out-l3out1/instP-net1/'
                'extsubnet-[200.200.100.0/24]')
+
+
+class TestHostLink(TestResourceOpsBase, base.TestAimDBBase):
+    resource_class = infra.HostLink
+    test_identity_attributes = {'host_name': 'h0',
+                                'interface_name': 'eth0'}
+    test_required_attributes = {'interface_mac': 'aa:bb:cc:dd:ee:ff',
+                                'switch_id': '201',
+                                'module': 'vpc-1-33',
+                                'port': 'bundle-201-1-33-and-202-1-33',
+                                'path': 'topology/pod-1/protpaths-201-202/'
+                                        'pathep-[bundle-201-1-33-and-'
+                                        '202-1-33]'}
+    test_search_attributes = {'host_name': 'h0'}
+    test_update_attributes = {'switch_id': '101',
+                              'module': '1',
+                              'port': '33',
+                              'path': 'topology/pod-1/paths-101/pathep-'
+                                      '[eth1/33]'}


### PR DESCRIPTION
Host connections to switch-ports can now be
managed as AIM resource. Also EndpointGroups
can now be statically bound to switch-ports.

Signed-off-by: Amit Bose <amitbose@gmail.com>