### PR TITLE
Propagate object status to the proper relatives

### DIFF
--- a/aim/api/status.py
+++ b/aim/api/status.py
@@ -58,7 +58,7 @@ class AciStatus(resource.ResourceBase, OperationalResource):
     def __init__(self, **kwargs):
         super(AciStatus, self).__init__({'resource_type': None,
                                          'resource_id': None,
-                                         'sync_status': self.SYNC_PENDING,
+                                         'sync_status': None,
                                          'sync_message': '',
                                          'health_score': 100,
                                          'faults': []}, **kwargs)

--- a/aim/db/hashtree_db_listener.py
+++ b/aim/db/hashtree_db_listener.py
@@ -59,6 +59,10 @@ class HashTreeDbListener(object):
                             ctx, res.parent_class, res.resource_id)
                         # Pretend that the object has been deleted
                         all_updates[-1].append(parent)
+                    elif res.sync_status == res.SYNC_PENDING:
+                        parent = self.aim_manager.get_by_id(
+                            ctx, res.parent_class, res.resource_id)
+                        all_updates[1].append(parent)
                 key = self.tt_maker.get_tenant_key(res)
                 if not key:
                     continue

--- a/aim/db/migration/alembic_migrations/versions/faade1155a0a_status_model.py
+++ b/aim/db/migration/alembic_migrations/versions/faade1155a0a_status_model.py
@@ -39,7 +39,7 @@ def upgrade():
         sa.Column('id', sa.String(36), primary_key=True),
         sa.Column('resource_type', sa.String(255), nullable=False),
         sa.Column('resource_id', sa.Integer, nullable=False),
-        sa.Column('sync_status', sa.String(50), nullable=False),
+        sa.Column('sync_status', sa.String(50), nullable=True),
         sa.Column('sync_message', sa.String(255), default=''),
         sa.Column('health_score', sa.Integer),
         sa.PrimaryKeyConstraint('id'),

--- a/aim/db/status_model.py
+++ b/aim/db/status_model.py
@@ -54,7 +54,7 @@ class Status(model_base.Base, model_base.HasId, model_base.AttributeMixin):
 
     resource_type = sa.Column(sa.String(255), nullable=False)
     resource_id = sa.Column(sa.Integer, nullable=False)
-    sync_status = sa.Column(sa.String(50), nullable=False)
+    sync_status = sa.Column(sa.String(50), nullable=True)
     sync_message = sa.Column(sa.String(255), default='')
     health_score = sa.Column(sa.Integer, nullable=False)
     faults = orm.relationship(Fault, backref='status')


### PR DESCRIPTION
- When sync status goes to FAILED, propagate to all the children
  recursively;
- When sync status goes to PENDING, propagate to parent (unless already
  synced) and children recursively (no object can be created without
  its parent anyways);
- When a new object is created in a subtree, apply the above.