### PR TITLE
Set tenant as a foreign key for AIM resources

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/3ef7607a41b0_contracts.py
+++ b/aim/db/migration/alembic_migrations/versions/3ef7607a41b0_contracts.py
@@ -42,7 +42,9 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
                             name='uniq_aim_filters_identity'),
-        sa.Index('idx_aim_filters_identity', 'tenant_name', 'name'))
+        sa.Index('idx_aim_filters_identity', 'tenant_name', 'name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name'], ['aim_tenants.name'], name='fk_flt_tn'))
 
     op.create_table(
         'aim_filter_entries',
@@ -85,7 +87,9 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
                             name='uniq_aim_contracts_identity'),
-        sa.Index('idx_aim_contracts_identity', 'tenant_name', 'name'))
+        sa.Index('idx_aim_contracts_identity', 'tenant_name', 'name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name'], ['aim_tenants.name'], name='fk_brc_tn'))
 
     op.create_table(
         'aim_contract_subjects',

--- a/aim/db/migration/alembic_migrations/versions/40855b7eb958_create_bridgedomain_table.py
+++ b/aim/db/migration/alembic_migrations/versions/40855b7eb958_create_bridgedomain_table.py
@@ -48,7 +48,9 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
                             name='uniq_aim_bridge_domains_identity'),
-        sa.Index('idx_aim_bridge_domains_identity', 'tenant_name', 'name'))
+        sa.Index('idx_aim_bridge_domains_identity', 'tenant_name', 'name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name'], ['aim_tenants.name'], name='fk_bd_tn'))
 
 
 def downgrade():

--- a/aim/db/migration/alembic_migrations/versions/7349fa0a2ad8_epg.py
+++ b/aim/db/migration/alembic_migrations/versions/7349fa0a2ad8_epg.py
@@ -34,10 +34,13 @@ import sqlalchemy as sa
 def upgrade():
     op.create_table(
         'aim_tenants',
+        sa.Column('aim_id', sa.Integer, autoincrement=True),
         sa.Column('name', sa.String(64), nullable=False),
         sa.Column('display_name', sa.String(256), nullable=False, default=''),
         sa.Column('monitored', sa.Boolean, nullable=False, default=False),
-        sa.PrimaryKeyConstraint('name'))
+        sa.PrimaryKeyConstraint('aim_id'),
+        sa.UniqueConstraint('name', name='uniq_aim_tenant_identity'),
+        sa.Index('idx_aim_tenant_identity', 'name'))
 
     op.create_table(
         'aim_subnets',
@@ -69,7 +72,9 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
                             name='uniq_aim_vrfs_identity'),
-        sa.Index('idx_aim_vrfs_identity', 'tenant_name', 'name'))
+        sa.Index('idx_aim_vrfs_identity', 'tenant_name', 'name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name'], ['aim_tenants.name'], name='fk_vrf_tn'))
 
     op.create_table(
         'aim_app_profiles',
@@ -81,7 +86,9 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
                             name='uniq_aim_app_profiles_identity'),
-        sa.Index('idx_aim_app_profiles_identity', 'tenant_name', 'name'))
+        sa.Index('idx_aim_app_profiles_identity', 'tenant_name', 'name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name'], ['aim_tenants.name'], name='fk_ap_tn'))
 
     op.create_table(
         'aim_endpoint_groups',

--- a/aim/db/migration/alembic_migrations/versions/8e313fbeb93b_l3out.py
+++ b/aim/db/migration/alembic_migrations/versions/8e313fbeb93b_l3out.py
@@ -53,7 +53,9 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
                             name='uniq_aim_l3outsides_identity'),
-        sa.Index('idx_aim_l3outsides_identity', 'tenant_name', 'name'))
+        sa.Index('idx_aim_l3outsides_identity', 'tenant_name', 'name'),
+        sa.ForeignKeyConstraint(
+            ['tenant_name'], ['aim_tenants.name'], name='fk_l3o_tn'))
 
     op.create_table(
         'aim_external_networks',

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -33,12 +33,14 @@ def uniq_column(table, *args, **kwargs):
 
 
 class Tenant(model_base.Base, model_base.HasDisplayName,
-             model_base.AttributeMixin, model_base.IsMonitored):
+             model_base.HasAimId,
+             model_base.AttributeMixin, model_base.IsMonitored,
+             model_base.HasName):
     """DB model for Tenant."""
 
     __tablename__ = 'aim_tenants'
-
-    name = model_base.name_column(primary_key=True)
+    __table_args__ = (uniq_column(__tablename__, 'name') +
+                      to_tuple(model_base.Base.__table_args__))
 
 
 class BridgeDomainL3Out(model_base.Base):
@@ -60,6 +62,9 @@ class BridgeDomain(model_base.Base, model_base.HasAimId,
 
     __tablename__ = 'aim_bridge_domains'
     __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      (sa.ForeignKeyConstraint(
+                          ['tenant_name'], ['aim_tenants.name'],
+                          name='fk_db_tn'),) +
                       to_tuple(model_base.Base.__table_args__))
 
     vrf_name = model_base.name_column()
@@ -119,6 +124,9 @@ class VRF(model_base.Base, model_base.HasAimId,
 
     __tablename__ = 'aim_vrfs'
     __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      (sa.ForeignKeyConstraint(
+                          ['tenant_name'], ['aim_tenants.name'],
+                          name='fk_vrf_tn'),) +
                       to_tuple(model_base.Base.__table_args__))
 
     policy_enforcement_pref = sa.Column(sa.String(16))
@@ -133,6 +141,9 @@ class ApplicationProfile(model_base.Base, model_base.HasAimId,
 
     __tablename__ = 'aim_app_profiles'
     __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      (sa.ForeignKeyConstraint(
+                          ['tenant_name'], ['aim_tenants.name'],
+                          name='fk_ap_tn'),) +
                       to_tuple(model_base.Base.__table_args__))
 
 
@@ -328,6 +339,9 @@ class Filter(model_base.Base, model_base.HasAimId,
 
     __tablename__ = 'aim_filters'
     __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      (sa.ForeignKeyConstraint(
+                          ['tenant_name'], ['aim_tenants.name'],
+                          name='fk_flt_tn'),) +
                       to_tuple(model_base.Base.__table_args__))
 
 
@@ -370,6 +384,9 @@ class Contract(model_base.Base, model_base.HasAimId,
 
     __tablename__ = 'aim_contracts'
     __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      (sa.ForeignKeyConstraint(
+                          ['tenant_name'], ['aim_tenants.name'],
+                          name='fk_brc_tn'),) +
                       to_tuple(model_base.Base.__table_args__))
 
     scope = sa.Column(sa.String(24))
@@ -470,6 +487,9 @@ class L3Outside(model_base.Base, model_base.HasAimId,
 
     __tablename__ = 'aim_l3outsides'
     __table_args__ = (uniq_column(__tablename__, 'tenant_name', 'name') +
+                      (sa.ForeignKeyConstraint(
+                          ['tenant_name'], ['aim_tenants.name'],
+                          name='fk_l3o_tn'),) +
                       to_tuple(model_base.Base.__table_args__))
 
     vrf_name = model_base.name_column()

--- a/aim/tests/unit/aim_lib/test_nat_strategy.py
+++ b/aim/tests/unit/aim_lib/test_nat_strategy.py
@@ -98,6 +98,7 @@ class TestNatStrategyBase(object):
                                 physical_domain_names=['phys'])]
 
     def test_l3outside(self):
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
         l3out = a_res.L3Outside(tenant_name='t1', name='o1',
                                 display_name='OUT')
         res = self.ns.create_l3outside(self.ctx, l3out)
@@ -117,6 +118,7 @@ class TestNatStrategyBase(object):
         self.assertEqual([], get_objs)
 
     def test_l3outside_multiple(self):
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
         l3out1 = a_res.L3Outside(tenant_name='t1', name='o1',
                                  display_name='OUT')
         self.ns.create_l3outside(self.ctx, l3out1)
@@ -152,6 +154,7 @@ class TestNatStrategyBase(object):
         self._verify(present=[l3out], absent=other_objs)
 
     def test_subnet(self):
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
         l3out = a_res.L3Outside(tenant_name='t1', name='o1',
                                 display_name='OUT')
         self.ns.create_l3outside(self.ctx, l3out)
@@ -172,6 +175,7 @@ class TestNatStrategyBase(object):
                                              '200.10.20.1/28'))
 
     def test_external_network(self):
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
         l3out = a_res.L3Outside(tenant_name='t1', name='o1',
                                 display_name='OUT')
         self.ns.create_l3outside(self.ctx, l3out)
@@ -221,6 +225,9 @@ class TestNatStrategyBase(object):
         ext_net = a_res.ExternalNetwork(
             tenant_name='t1', l3out_name='o1', name='inet1',
             display_name='INET1')
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept2'))
         self.ns.create_l3outside(self.ctx, l3out)
         self.ns.create_external_network(self.ctx, ext_net)
         self.ns.update_external_cidrs(self.ctx, ext_net,
@@ -264,6 +271,8 @@ class TestNatStrategyBase(object):
         ext_net = a_res.ExternalNetwork(
             tenant_name='t1', l3out_name='o1', name='inet1',
             display_name='INET1')
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept1'))
         self.ns.create_l3outside(self.ctx, l3out)
         self.ns.create_external_network(self.ctx, ext_net)
 
@@ -294,6 +303,8 @@ class TestNatStrategyBase(object):
         ext_net = a_res.ExternalNetwork(
             tenant_name='t1', l3out_name='o1', name='inet1',
             display_name='INET1')
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept1'))
         self.ns.create_l3outside(self.ctx, l3out)
         self.ns.create_external_network(self.ctx, ext_net)
         self.ns.update_external_cidrs(self.ctx, ext_net,
@@ -323,6 +334,9 @@ class TestNatStrategyBase(object):
         ext_net1 = a_res.ExternalNetwork(
             tenant_name='t1', l3out_name='o1', name='inet1',
             display_name='INET1')
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='t2'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept1'))
         self.ns.create_l3outside(self.ctx, l3out1)
         self.ns.create_external_network(self.ctx, ext_net1)
         self.ns.update_external_cidrs(self. ctx, ext_net1,
@@ -364,6 +378,9 @@ class TestNatStrategyBase(object):
         ext_net = a_res.ExternalNetwork(
             tenant_name='t1', l3out_name='o1', name='inet1',
             display_name='INET1')
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept2'))
         self.ns.create_l3outside(self.ctx, l3out)
         self.ns.create_external_network(self.ctx, ext_net)
         self.ns.update_external_cidrs(self. ctx, ext_net,
@@ -389,6 +406,8 @@ class TestNatStrategyBase(object):
         self._check_delete_ext_net_with_vrf('stage2')
 
     def test_delete_l3outside_with_vrf(self):
+        self.mgr.create(self.ctx, a_res.Tenant(name='t1'))
+        self.mgr.create(self.ctx, a_res.Tenant(name='dept1'))
         l3out = a_res.L3Outside(tenant_name='t1', name='o1',
                                 display_name='OUT')
         ext_net = a_res.ExternalNetwork(

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -423,6 +423,7 @@ class TestTenantMixin(object):
 
 
 class TestBridgeDomainMixin(object):
+    prereq_objects = [resource.Tenant(name='tenant1')]
     resource_class = resource.BridgeDomain
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'name': 'net1'}
@@ -462,6 +463,7 @@ class TestAgentMixin(object):
 
 class TestSubnetMixin(object):
     prereq_objects = [
+        resource.Tenant(name='tenant1'),
         resource.BridgeDomain(tenant_name='tenant1', name='net1')]
     gw_ip = resource.Subnet.to_gw_ip_mask('192.168.10.1', 28)
     resource_class = resource.Subnet
@@ -482,6 +484,7 @@ class TestSubnetMixin(object):
 
 class TestVRFMixin(object):
     resource_class = resource.VRF
+    prereq_objects = [resource.Tenant(name='tenant1')]
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'name': 'shared'}
     test_required_attributes = {'tenant_name': 'tenant1',
@@ -498,6 +501,7 @@ class TestVRFMixin(object):
 
 class TestApplicationProfileMixin(object):
     resource_class = resource.ApplicationProfile
+    prereq_objects = [resource.Tenant(name='tenant1')]
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'name': 'lab'}
     test_required_attributes = {'tenant_name': 'tenant1',
@@ -512,6 +516,7 @@ class TestApplicationProfileMixin(object):
 class TestEndpointGroupMixin(object):
     resource_class = resource.EndpointGroup
     prereq_objects = [
+        resource.Tenant(name='tenant1'),
         resource.ApplicationProfile(tenant_name='tenant1', name='lab'),
         resource.VMMDomain(type='OpenStack', name='openstack'),
         resource.PhysicalDomain(name='phys')]
@@ -557,6 +562,7 @@ class TestEndpointGroupMixin(object):
 
 class TestFilterMixin(object):
     resource_class = resource.Filter
+    prereq_objects = [resource.Tenant(name='tenant1')]
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'name': 'filter1'}
     test_required_attributes = {'tenant_name': 'tenant1',
@@ -571,6 +577,7 @@ class TestFilterMixin(object):
 class TestFilterEntryMixin(object):
     resource_class = resource.FilterEntry
     prereq_objects = [
+        resource.Tenant(name='tenant1'),
         resource.Filter(tenant_name='tenant1', name='filter1')]
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'filter_name': 'filter1',
@@ -606,6 +613,7 @@ class TestFilterEntryMixin(object):
 
 class TestContractMixin(object):
     resource_class = resource.Contract
+    prereq_objects = [resource.Tenant(name='tenant1')]
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'name': 'contract1'}
     test_required_attributes = {'tenant_name': 'tenant1',
@@ -621,6 +629,7 @@ class TestContractMixin(object):
 class TestContractSubjectMixin(object):
     resource_class = resource.ContractSubject
     prereq_objects = [
+        resource.Tenant(name='tenant1'),
         resource.Contract(tenant_name='tenant1', name='contract1')]
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'contract_name': 'contract1',
@@ -644,6 +653,7 @@ class TestContractSubjectMixin(object):
 class TestEndpointMixin(object):
     resource_class = resource.Endpoint
     prereq_objects = [
+        resource.Tenant(name='t1'),
         resource.ApplicationProfile(tenant_name='t1', name='lab'),
         resource.ApplicationProfile(tenant_name='t1', name='dept'),
         resource.EndpointGroup(tenant_name='t1', app_profile_name='lab',
@@ -686,6 +696,7 @@ class TestPhysicalDomainMixin(object):
 
 class TestL3OutsideMixin(object):
     resource_class = resource.L3Outside
+    prereq_objects = [resource.Tenant(name='tenant1')]
     test_identity_attributes = {'tenant_name': 'tenant1',
                                 'name': 'l3out1'}
     test_required_attributes = {'tenant_name': 'tenant1',
@@ -702,6 +713,7 @@ class TestL3OutsideMixin(object):
 class TestExternalNetworkMixin(object):
     resource_class = resource.ExternalNetwork
     prereq_objects = [
+        resource.Tenant(name='tenant1'),
         resource.L3Outside(tenant_name='tenant1', name='l3out1',
                            vrf_name='ctx1', l3_domain_dn='uni/foo')]
     test_identity_attributes = {'tenant_name': 'tenant1',
@@ -726,6 +738,7 @@ class TestExternalNetworkMixin(object):
 class TestExternalSubnetMixin(object):
     resource_class = resource.ExternalSubnet
     prereq_objects = [
+        resource.Tenant(name='tenant1'),
         resource.L3Outside(tenant_name='tenant1', name='l3out1'),
         resource.ExternalNetwork(tenant_name='tenant1', l3out_name='l3out1',
                                  name='net1')]

--- a/aim/tests/unit/test_hashtree_db_listener.py
+++ b/aim/tests/unit/test_hashtree_db_listener.py
@@ -212,14 +212,18 @@ class TestHashTreeDbListener(base.TestAimDBBase):
                 tenant_name=tn_name, app_profile_name='ap', name='epg',
                 bd_name='some')
             # Add Tenant and AP
+            self.mgr.create(self.ctx, aim_res.Tenant(name=tn_name))
+            # Called twice, one for tenant and one for Fault
+            exp_calls = [
+                mock.call(mock.ANY, 'serve', None),
+                mock.call(mock.ANY, 'reconcile', None)]
+            self._check_call_list(exp_calls, cast)
             self.mgr.create(self.ctx, tn)
-            cast.assert_called_once_with(mock.ANY, 'serve', None)
             cast.reset_mock()
             self.mgr.create(self.ctx, ap)
             self.mgr.create(self.ctx, epg)
             # Create AP will create tenant, create EPG will modify it
             exp_calls = [
-                mock.call(mock.ANY, 'serve', None),
                 mock.call(mock.ANY, 'reconcile', None),
                 mock.call(mock.ANY, 'reconcile', None)]
             self._check_call_list(exp_calls, cast)

--- a/aim/tests/unit/tools/cli/test_manager.py
+++ b/aim/tests/unit/tools/cli/test_manager.py
@@ -43,6 +43,7 @@ class TestManager(base.TestShell):
             tenant_name='tn1', app_profile_name='ap', name='epg1')
         pre_epg2 = resource.EndpointGroup(
             tenant_name='tn1', app_profile_name='ap', name='epg2')
+        self.mgr.create(self.ctx, resource.Tenant(name='tn1'))
         self.mgr.create(self.ctx, ap)
         self.mgr.create(self.ctx, pre_phys)
         self.mgr.create(self.ctx, pre_vmm)


### PR DESCRIPTION
New semantics:

- Tenant object must always exist in order for children to be
  created;
- Tenant object now supports faults;
- When deleting an AIM object, the AIM manager will try to delete
  its whole monitored subtree.