### PR TITLE
Use thread monitors to rotate between APIC hosts

### DIFF
--- a/aim/config.py
+++ b/aim/config.py
@@ -443,8 +443,8 @@ class ConfigSubscriber(gevent.Greenlet):
         configs = {}
         # Copy the sub dictionary which might change during the iteration
         for group, items in copy.copy(self.subscription_map).iteritems():
-            for item, callbacks in items.iteritems():
-                for call_id, values in callbacks.iteritems():
+            for item, callbacks in copy.copy(items).iteritems():
+                for call_id, values in copy.copy(callbacks).iteritems():
                     for host in values['hosts']:
                         try:
                             # TODO(ivar): optimize to make a single DB call

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -246,11 +246,17 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         self.assertTrue(current_ws is self.universe.ws_context.session)
 
     def test_thread_monitor(self):
-        self.universe.ws_context.monitor_runs = 1
+        self.set_override('apic_hosts', ['3.1.1.1', '3.1.1.2', '3.1.1.3'],
+                          'apic')
+        self.universe.ws_context._reload_websocket_config()
+        self.universe.ws_context.monitor_runs = 4
+        self.universe.ws_context.monitor_max_backoff = 0
+        self.universe.ws_context.monitor_sleep_time = 0
         t = mock.Mock()
         t.isAlive = mock.Mock(return_value=False)
         with mock.patch.object(utils, 'perform_harakiri') as harakiri:
             self.universe.ws_context._thread_monitor(t, 'test')
+            self.assertEqual(4, t.isAlive.call_count)
             harakiri.assert_called_once_with(mock.ANY, mock.ANY)
             harakiri.reset_mock()
             t.isAlive = mock.Mock(return_value=True)


### PR DESCRIPTION
Whenever we see a websocket critical thread die, rotate the
list of APIC IP addresses and retry WS connection. Eventually
dies after running out of IPs.