### PR TITLE
Better handling of fast events

### DIFF
--- a/aim/agent/aid/event_services/rpc.py
+++ b/aim/agent/aid/event_services/rpc.py
@@ -71,7 +71,8 @@ class AIDEventRpcApi(object):
     def tree_creation_postcommit(self, session, added, updated, deleted):
         if added or deleted:
             self.serve({})
-        if updated:
+        elif updated:
+            # Serve implies a reconcile
             self.reconcile({})
 
 


### PR DESCRIPTION
Sometimes, multiple events can reach the same AIM tenant regarding
the same set of objects. In these cases, multiple subsequent failures
are possible and can lead to a premature setting of the error state
for an AIM object. In order to mitigate this problem, the following
actions are taken:

- Squash similar events in the ACI tenant manager to avoid creating
too many duplicates in APIC;
- Add a failure cooldown period in which a specific item can keep
failing without increasing the number of tentatives before impacting
its sync state.

The root cause of this problem, to be addressed by a subsequent patch,
is that notification events are sent by the AIM manager before the
DB transaction actually commits! So we end up sending multiple
"reconcile" events within a single transaction, and AID ends up
looking at an "unfinished" state. This is OK in principle and should
be handled properly, since a poller event could cause the same thing,
but we should figure out what is the proper commit hook for the
AIM Tree Manager as "after_commit" doesn't seem to work as expected.

Closes noironetworks/support#415