### PR TITLE
Avoid deleting objects when in error state

### DIFF
--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -69,7 +69,7 @@ class ResourceBase(object):
     @property
     def members(self):
         return {x: self.__dict__[x] for x in self.attributes() +
-                ['pre_existing'] if x in self.__dict__}
+                ['pre_existing'] + ['_error'] if x in self.__dict__}
 
     def __str__(self):
         return '%s(%s)' % (type(self).__name__, ','.join(self.identity))

--- a/aim/common/hashtree/structured_tree.py
+++ b/aim/common/hashtree/structured_tree.py
@@ -35,13 +35,14 @@ class StructuredTreeNode:
                          # to the resource from which this node was generated
         'full_hash',  # hash(partial_hash, children.full_hash)
         'dummy',  # whether or not this node is dummy
+        'error',  # When True, skip to compare children
         '_children',  # underlying nodes
         'metadata'  # Additional "user" data dict, not used for
                     # tree comparison
     ]
 
     def __init__(self, key, partial_hash=None, full_hash=None, dummy=True,
-                 metadata=None):
+                 metadata=None, error=False):
         self.key = key
         self.partial_hash = partial_hash
         # Same as partial hash by default
@@ -49,6 +50,7 @@ class StructuredTreeNode:
         self._children = ChildrenList()
         self.dummy = dummy
         self.metadata = metadata or {}
+        self.error = error
 
     def __cmp__(self, other):
         return cmp(self.key, getattr(other, 'key', other))
@@ -75,7 +77,8 @@ class StructuredTreeNode:
         root = collections.OrderedDict(
             [('key', self.key), ('partial_hash', self.partial_hash),
              ('full_hash', self.full_hash), ('dummy', self.dummy),
-             ('_children', []), ('metadata', self.metadata)])
+             ('error', self.error), ('_children', []),
+             ('metadata', self.metadata)])
         for children in self.get_children():
             root['_children'].append(children.to_dict())
         return root
@@ -224,6 +227,7 @@ class StructuredHashTree(base.ComparableCollection):
                                   root_dict['partial_hash'],
                                   root_dict['full_hash'],
                                   dummy=root_dict['dummy'],
+                                  error=root_dict['error'],
                                   metadata=root_dict.get('metadata'))
         for child in root_dict['_children']:
             root._children.add(StructuredHashTree._build_tree(child))
@@ -236,12 +240,13 @@ class StructuredHashTree(base.ComparableCollection):
             return self
         has_metadata = '_metadata' in kwargs
         metadata = kwargs.pop('_metadata', None)
+        error = kwargs.pop('_error', False)
         # When self.root is node, it gets initialized with a bogus node
         if not self.root:
             LOG.debug("Root initialized")
             self.root = StructuredTreeNode(
                 (key[0],), self._hash_attributes(key=(key[0],)),
-                metadata=metadata)
+                metadata=metadata, error=error)
             self.root_key = self.root.key
         else:
             # With the first element of the key, verify that this is not an
@@ -265,6 +270,7 @@ class StructuredHashTree(base.ComparableCollection):
         node.partial_hash = self._hash_attributes(key=key, **kwargs)
         # When a node is explicitly added, it is not dummy anymore
         node.dummy = False
+        node.error = error
         if has_metadata:
             node.metadata = metadata or {}
         # Recalculate full hashes navigating the stack backwards
@@ -368,9 +374,10 @@ class StructuredHashTree(base.ComparableCollection):
             else:
                 # Common child
                 if childrenl[node.key].partial_hash != node.partial_hash:
-                    LOG.debug("Node %s out of sync" % str(node.key))
-                    # This node needs to be modified as well
-                    result['add'].append(node.key)
+                    if not (node.error or childrenl[node.key].error):
+                        LOG.debug("Node %s out of sync" % str(node.key))
+                        # This node needs to be modified as well
+                        result['add'].append(node.key)
                 if childrenl[node.key].full_hash != node.full_hash:
                     # Evaluate all their children
                     self._diff_children(childrenl[node.key]._children,
@@ -386,7 +393,7 @@ class StructuredHashTree(base.ComparableCollection):
         # traverse the tree and returns all its keys
         if not root:
             return []
-        result = [root.key] if not root.dummy else []
+        result = [root.key] if not (root.dummy or root.error) else []
         for node in root.get_children():
             result += self._get_subtree_keys(node)
         return result

--- a/aim/db/hashtree_db_listener.py
+++ b/aim/db/hashtree_db_listener.py
@@ -57,9 +57,11 @@ class HashTreeDbListener(object):
                     # Remove main object from config tree if in sync error
                     # during an update
                     if res.sync_status == res.SYNC_FAILED:
-                        if tree_index == 0:
-                            # Pretend that the object has been deleted
-                            all_updates[-1].append(parent)
+                        parent = self.aim_manager.get_by_id(
+                            ctx, res.parent_class, res.resource_id)
+                        # Put the object in error state
+                        parent._error = True
+                        all_updates[1].append(parent)
                     elif res.sync_status == res.SYNC_PENDING:
                         # A sync pending monitored object is in a limbo state,
                         # potentially switching from Owned to Monitored, and
@@ -125,7 +127,6 @@ class HashTreeDbListener(object):
                 udp_op_trees.append(ttree_operational)
             if ttree_monitor.root_key:
                 udp_mon_trees.append(ttree_monitor)
-
         # Finally save the modified trees
         if upd_trees:
             self.tt_mgr.update_bulk(ctx, upd_trees)


### PR DESCRIPTION
Today, every time ad AIM object gets in SYNC_FAILED state, we
remove the corresponding entry from the proper hashtree. This can
sometimes cause unexpected datapath loss due to the subsequent
deletion of the object itself from APIC.

For example, an ACI VRF would face deletion from APIC just because
an update to its display name set an invalid value! To avoid
such issue, this patch puts the hashtree node in a new state called
"error" instead of deleting it from the tree. When a node is in error
state, it will be excluded from the hashtree difference calculation
without stopping the procedure, so that its subtree can be checked
for inconsistencies.

TODO: error nodes still participate the hash calculation, making the
diff operation more inefficient when such nodes are present.