### PR TITLE
Introduce error categories for better exception handling

### DIFF
--- a/aim/agent/aid/universes/aci/error.py
+++ b/aim/agent/aid/universes/aci/error.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2017 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from requests import exceptions as request_exc
+
+from apicapi import exceptions as apicapi_exc
+from oslo_log import log as logging
+
+from aim.agent.aid.universes import errors
+
+LOG = logging.getLogger(__name__)
+
+
+class APICErrorHandler(object):
+    """APIC Error Handler.
+
+    For each error type returned during a write operation in APIC, including
+    errors caused by temporary network partition, categorize each failure
+    into a defined superset of a few enumerations that can be used by the
+    caller to decide which action is the best to be taken after such failure.
+
+    """
+
+    APIC_OBJECT_CRITICAL = set([122, 121, 120, 106])
+    APIC_OBJECT_TRANSIENT = set([100, 102])
+
+    def analyze_request_exception(self, e):
+        if isinstance(e, request_exc.Timeout):
+            LOG.warn("APIC didn't respond and the request timed out.")
+            return errors.SYSTEM_TRANSIENT
+        elif isinstance(e, request_exc.ConnectionError):
+            return errors.SYSTEM_TRANSIENT
+        elif isinstance(e, request_exc.URLRequired):
+            return errors.OPERATION_CRITICAL
+        elif isinstance(e, request_exc.InvalidURL):
+            return errors.OPERATION_CRITICAL
+        elif isinstance(e, request_exc.RequestException):
+            LOG.warn("A generic request exception occurred: %s", e.message)
+            return errors.OPERATION_TRANSIENT
+        else:
+            LOG.warn("An unknown error occurred: %s", e.message)
+            return errors.UNKNOWN
+
+    def analyze_apic_error(self, error_status, error_code):
+        if error_status == 400:
+            if error_code in self.APIC_OBJECT_CRITICAL:
+                return errors.OPERATION_CRITICAL
+            if error_code in self.APIC_OBJECT_TRANSIENT:
+                return errors.OPERATION_TRANSIENT
+            else:
+                LOG.warn("Unmanaged error code %s from APIC", error_code)
+                return errors.UNKNOWN
+        elif error_status == 403:
+            LOG.warn("Forbidden operation, re-login required.")
+            return errors.SYSTEM_TRANSIENT
+        elif error_status >= 500:
+            LOG.warn("Server error, APIC might recover by itself.")
+            return errors.SYSTEM_TRANSIENT
+        else:
+            LOG.warn("Unknown status code %s from APIC", error_status)
+            return errors.UNKNOWN
+
+
+class APICAPIErrorHandler(APICErrorHandler):
+    """Error handling for the APICAPI library."""
+
+    def __init__(self):
+        self.apicapi_error_handlers = {
+            # Most commonly returned exception by APICAPI when the network
+            # is properly working but the operation cannot be completed.
+            apicapi_exc.ApicResponseNotOk: (self._handle_apic_error, ""),
+            apicapi_exc.ApicResponseNoCookie: (
+                self._return_system_critical,
+                "During a login operation, APIC returned properly but for "
+                "some reason the login Cookie is missing. Needs manual "
+                "intervention"),
+            # APICAPI wraps Timeout errors into ApicHostNoResponse exceptions.
+            # These are usually considerate system transient.
+            apicapi_exc.ApicHostNoResponse: (
+                self._return_system_transient,
+                "APIC didn't respond and the request timed out."),
+            # The transaction is not built properly, this operation will never
+            # succeed
+            apicapi_exc.ApicInvalidTransactionMultipleRoot: (
+                self._return_operation_critical,
+                "The transaction is not built properly, this operation "
+                "will never succeed"),
+            apicapi_exc.ApicManagedObjectNotSupported: (
+                self._return_operation_critical,
+                "The requested APIC object is not supported by the APICPI "
+                "client, this operation will never succeed."
+                "(apicapi upgrade might be required"),
+            apicapi_exc.ApicSessionNotLoggedIn: (
+                self._return_system_transient,
+                "The APICAPI client is not logged in."
+            )
+        }
+
+    def analyze_exception(self, e):
+        """Analyze an apic_client exception from the APICAPI module.
+
+        :param e:
+        :return: the proper error type enumeration
+        """
+        err_func, msg = self.apicapi_error_handlers.get(
+            type(e), (self.analyze_request_exception, ''))
+        err_type = err_func(e)
+        if msg:
+            if err_type in errors.CRITICAL_ERRORS:
+                LOG.error(msg)
+            else:
+                LOG.warn(msg)
+        return err_type
+
+    def _handle_apic_error(self, e):
+        try:
+            status = int(e.err_status)
+        except ValueError:
+            status = 0
+
+        try:
+            code = int(e.err_code)
+        except ValueError:
+            code = 0
+
+        return self.analyze_apic_error(status, code)
+
+    def _return_system_critical(self, e):
+        return errors.SYSTEM_CRITICAL
+
+    def _return_system_transient(self, e):
+        return errors.SYSTEM_TRANSIENT
+
+    def _return_operation_critical(self, e):
+        return errors.OPERATION_CRITICAL

--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -27,6 +27,7 @@ from oslo_log import log as logging
 
 from aim.agent.aid import event_handler
 from aim.agent.aid.universes.aci import converter
+from aim.agent.aid.universes.aci import error
 from aim.agent.aid.universes import base_universe
 from aim.common.hashtree import structured_tree
 from aim.common import utils
@@ -162,6 +163,7 @@ class AciTenantManager(gevent.Greenlet):
         self.ws_context = ws_context
         self.recovery_retries = None
         self.max_retries = 5
+        self.error_handler = error.APICAPIErrorHandler()
 
     def is_dead(self):
         # Wrapping the greenlet property for easier testing
@@ -387,7 +389,7 @@ class AciTenantManager(gevent.Greenlet):
                         # Object creation was successful, change object state
                         if method == base_universe.CREATE:
                             self.creation_succeeded(aim_object)
-                    except apic_exc.ApicResponseNotOk as e:
+                    except Exception as e:
                         LOG.debug(traceback.format_exc())
                         try:
                             printable = aim_object.__dict__
@@ -396,7 +398,13 @@ class AciTenantManager(gevent.Greenlet):
                         LOG.error("An error as occurred during %s for "
                                   "object %s" % (method, printable))
                         if method == base_universe.CREATE:
-                            self.creation_failed(aim_object, e.msg)
+                            err_type = self.error_handler.analyze_exception(e)
+                            # REVISIT(ivar): for now, treat UNKNOWN errors the
+                            # same way as OPERATION_TRANSIENT. Investigate a
+                            # way to understand when such errors might require
+                            # agent restart.
+                            self.creation_failed(aim_object, e.message,
+                                                 err_type)
 
     def _unsubscribe_tenant(self):
         LOG.debug("Unsubscribing tenant websocket %s" % self.tenant_name)

--- a/aim/agent/aid/universes/errors.py
+++ b/aim/agent/aid/universes/errors.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2017 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+# unknown error
+UNKNOWN = 'unknown'
+# the operation will never succeed (eg. malformed object)
+OPERATION_CRITICAL = 'operation_critical'
+# the operation might eventually succeed and it's failing for temporary
+# reasons (eg. object parent doesn't exist during creation)
+OPERATION_TRANSIENT = 'operation_transient'
+# the whole system is broken and cannot be recovered regardless of the
+# operation (eg. wrong APIC certificate or credentials)
+SYSTEM_CRITICAL = 'system_critical'
+# the system is currently broken regardless of the operation, but might
+# recover eventually (eg. network partition)
+SYSTEM_TRANSIENT = 'system_transient'
+
+SUPPORTED_ERRORS = [UNKNOWN, OPERATION_CRITICAL, OPERATION_TRANSIENT,
+                    SYSTEM_CRITICAL, SYSTEM_TRANSIENT]
+CRITICAL_ERRORS = [OPERATION_CRITICAL, SYSTEM_CRITICAL]
+TRANSIENT_ERRORS = [OPERATION_TRANSIENT, SYSTEM_TRANSIENT]
+OPERATION_ERRORS = [OPERATION_CRITICAL, OPERATION_TRANSIENT]
+SYSTEM_ERRORS = [SYSTEM_TRANSIENT, SYSTEM_CRITICAL]

--- a/aim/config.py
+++ b/aim/config.py
@@ -67,6 +67,9 @@ agent_opts = [
     cfg.IntOpt('max_operation_retry', default=5,
                help="How many creations/deletions are attempted by AID before "
                     "declaring failure on a specific object"),
+    cfg.IntOpt('retry_cooldown', default=3,
+               help="How many seconds AID needs to wait between the same "
+                    "failure before considering it a new tentative"),
     cfg.StrOpt('unix_socket_path', default='/run/aid/events/aid.sock',
                help="Host where this agent/controller is running"),
     cfg.BoolOpt('recovery_restart', default=True,

--- a/aim/tests/unit/agent/aid_universes/test_aci_error.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_error.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from requests import exceptions as rexc
+
+from aim.agent.aid.universes.aci import error
+from aim.agent.aid.universes import errors
+from aim.tests import base
+
+from apicapi import exceptions
+
+
+class TestACIError(base.BaseTestCase):
+
+    def setUp(self):
+        super(TestACIError, self).setUp()
+        self.apic_handler = error.APICAPIErrorHandler()
+        self.base_handler = error.APICErrorHandler()
+
+    def test_analyze_exception_no_cookie(self):
+        self.assertEqual(
+            errors.SYSTEM_CRITICAL,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicResponseNoCookie(request='')))
+
+    def test_analyze_exception_no_response(self):
+        self.assertEqual(
+            errors.SYSTEM_TRANSIENT,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicHostNoResponse(url='')))
+
+    def test_analyze_exception_invalid_transaction(self):
+        self.assertEqual(
+            errors.OPERATION_CRITICAL,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicInvalidTransactionMultipleRoot()))
+
+    def test_analyze_exception_mo_not_supported(self):
+        self.assertEqual(
+            errors.OPERATION_CRITICAL,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicManagedObjectNotSupported(mo_class='')))
+
+    def test_analyze_exception_session_not_logged_in(self):
+        self.assertEqual(
+            errors.SYSTEM_TRANSIENT,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicSessionNotLoggedIn()))
+
+    def test_analyze_exception_not_ok(self):
+        for err_code in self.base_handler.APIC_OBJECT_CRITICAL:
+            self.assertEqual(
+                errors.OPERATION_CRITICAL,
+                self.apic_handler.analyze_exception(
+                    exceptions.ApicResponseNotOk(
+                        request='', status='400', reason='',
+                        err_text='', err_code=str(err_code))))
+
+        for err_code in self.base_handler.APIC_OBJECT_TRANSIENT:
+            self.assertEqual(
+                errors.OPERATION_TRANSIENT,
+                self.apic_handler.analyze_exception(
+                    exceptions.ApicResponseNotOk(
+                        request='', status='400', reason='',
+                        err_text='', err_code=str(err_code))))
+
+        self.assertEqual(
+            errors.SYSTEM_TRANSIENT,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicResponseNotOk(
+                    request='', status='403', reason='',
+                    err_text='', err_code='')))
+
+        self.assertEqual(
+            errors.SYSTEM_TRANSIENT,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicResponseNotOk(
+                    request='', status='500', reason='',
+                    err_text='', err_code='')))
+
+        self.assertEqual(
+            errors.UNKNOWN,
+            self.apic_handler.analyze_exception(
+                exceptions.ApicResponseNotOk(
+                    request='', status='300', reason='',
+                    err_text='', err_code='')))
+
+    def test_analyze_exception_request(self):
+        self.assertEqual(
+            errors.SYSTEM_TRANSIENT,
+            self.apic_handler.analyze_exception(rexc.Timeout()))
+        self.assertEqual(
+            errors.SYSTEM_TRANSIENT,
+            self.apic_handler.analyze_exception(rexc.ConnectionError()))
+        self.assertEqual(
+            errors.OPERATION_CRITICAL,
+            self.apic_handler.analyze_exception(rexc.InvalidURL()))
+        self.assertEqual(
+            errors.OPERATION_CRITICAL,
+            self.apic_handler.analyze_exception(rexc.URLRequired()))
+        self.assertEqual(
+            errors.OPERATION_TRANSIENT,
+            self.apic_handler.analyze_exception(rexc.RequestException()))
+        self.assertEqual(
+            errors.UNKNOWN,
+            self.apic_handler.analyze_exception(Exception()))

--- a/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
@@ -201,7 +201,7 @@ class TestAciClientMixin(object):
                                 curr = next[part[0]]['children']
                             else:
                                 raise apic_client.cexc.ApicResponseNotOk(
-                                    status='bad request', reason='bad request',
+                                    status=400, reason='bad request',
                                     request='create', err_code=400,
                                     err_text='bad request')
                         else:

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -14,9 +14,11 @@
 #    under the License.
 
 import json
+from requests import exceptions as rexc
 import time
 
 from apicapi import apic_client
+from apicapi import exceptions as aexc
 import mock
 from oslo_db import exception
 
@@ -26,6 +28,7 @@ from aim import aim_manager
 from aim.api import resource
 from aim.api import status as aim_status
 from aim.common.hashtree import structured_tree as tree
+from aim.common import utils
 from aim import config
 from aim.db import tree_model
 from aim.tests import base
@@ -997,6 +1000,96 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertIsNotNone(l3o)
         self.assertTrue(l3o.monitored)
         self.assertEqual('foo', l3o.vrf_name)
+
+    def test_aci_errors(self):
+        self.set_override('max_operation_retry', 2, 'aim')
+        self.set_override('retry_cooldown', -1, 'aim')
+        agent = self._create_agent()
+        tenant_name = 'test_manual_rs'
+        current_config = agent.multiverse[0]['current']
+        tn = resource.Tenant(name=tenant_name)
+        tn = self.aim_manager.create(self.ctx, tn)
+        # Serve tenant
+        agent._daemon_loop()
+        # Try to create the tenant in multiple iterations and test different
+        # errors
+        with mock.patch.object(utils, 'perform_harakiri') as harakiri:
+            # OPERATION_CRITICAL (fail object immediately)
+            apic_client.ApicSession.post_body_dict = mock.Mock(
+                side_effect=aexc.ApicResponseNotOk(
+                    request='', status='400', reason='',
+                    err_text='', err_code='122'))
+            # Observe and Reconcile
+            self._observe_aci_events(current_config)
+            agent._daemon_loop()
+            # Tenant object should be in sync_error state
+            self.assertEqual(
+                aim_status.AciStatus.SYNC_FAILED,
+                self.aim_manager.get_status(self.ctx, tn).sync_status)
+            # Put tenant back in pending state
+            self.aim_manager.update(self.ctx, tn)
+            agent._daemon_loop()
+
+            # OPERATION_TRANSIENT (fail object after max retries)
+            apic_client.ApicSession.post_body_dict = mock.Mock(
+                side_effect=aexc.ApicResponseNotOk(
+                    request='', status='400', reason='',
+                    err_text='', err_code='102'))
+            # Observe and Reconcile
+            self._observe_aci_events(current_config)
+            agent._daemon_loop()
+            # Tenant is still in SYNC_PENDING state
+            self.assertEqual(
+                aim_status.AciStatus.SYNC_PENDING,
+                self.aim_manager.get_status(self.ctx, tn).sync_status)
+            # Another tentative, however, will fail the object
+            self._observe_aci_events(current_config)
+            agent._daemon_loop()
+            # Tenant is still in SYNC_PENDING state
+            self.assertEqual(
+                aim_status.AciStatus.SYNC_FAILED,
+                self.aim_manager.get_status(self.ctx, tn).sync_status)
+            # Put tenant back in pending state
+            self.aim_manager.update(self.ctx, tn)
+
+            # SYSTEM_TRANSIENT (never fail the object)
+            apic_client.ApicSession.post_body_dict = mock.Mock(
+                side_effect=rexc.Timeout())
+            # This will not fail the object
+            for x in range(3):
+                # Observe and Reconcile
+                self._observe_aci_events(current_config)
+                agent._daemon_loop()
+                # Tenant is still in SYNC_PENDING state
+                self.assertEqual(
+                    aim_status.AciStatus.SYNC_PENDING,
+                    self.aim_manager.get_status(self.ctx, tn).sync_status)
+
+            # SYSTEM_CRITICAL perform harakiri
+            apic_client.ApicSession.post_body_dict = mock.Mock(
+                side_effect=aexc.ApicResponseNoCookie(request=''))
+            self.assertEqual(0, harakiri.call_count)
+            self._observe_aci_events(current_config)
+            agent._daemon_loop()
+            self.assertEqual(1, harakiri.call_count)
+
+            # UNKNOWN (fail after max retries)
+            apic_client.ApicSession.post_body_dict = mock.Mock(
+                side_effect=Exception())
+            # Observe and Reconcile
+            self._observe_aci_events(current_config)
+            agent._daemon_loop()
+            # Tenant is still in SYNC_PENDING state
+            self.assertEqual(
+                aim_status.AciStatus.SYNC_PENDING,
+                self.aim_manager.get_status(self.ctx, tn).sync_status)
+            # Another tentative, however, will fail the object
+            self._observe_aci_events(current_config)
+            agent._daemon_loop()
+            # Tenant is still in SYNC_PENDING state
+            self.assertEqual(
+                aim_status.AciStatus.SYNC_FAILED,
+                self.aim_manager.get_status(self.ctx, tn).sync_status)
 
     def _observe_aci_events(self, aci_universe):
         for tenant in aci_universe.serving_tenants.values():


### PR DESCRIPTION
We define a few error categories, each of which has a different
impact on the universe handling it:

- OPERATION_CRITICAL: the operation will never succeed (eg. malformed
  object), universe will put the corresponding item in error state;
- OPERATION_TRANSIENT: the operation might eventually succeed and it's
  failing for temporary reasons (eg. object parent doesn't exist
  during creation), universe will retry until configured tentatives;
- SYSTEM_TRANSIENT: the system is currently broken regardless of the
  operation, but might recover eventually (eg. network partition),
  this category is currently ignored;
- SYSTEM_CRITICAL: the whole system is broken and cannot be recovered
  regardless of the operation (eg. wrong APIC certificate or
  credentials), the universe will terminate the AID process.