### PR TITLE
Remove FK constraint from EPG's domains

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/1249face3348_domains.py
+++ b/aim/db/migration/alembic_migrations/versions/1249face3348_domains.py
@@ -51,10 +51,7 @@ def upgrade():
         sa.Column('vmm_name', sa.String(64), nullable=False),
         sa.PrimaryKeyConstraint('epg_aim_id', 'vmm_type', 'vmm_name'),
         sa.ForeignKeyConstraint(
-            ['epg_aim_id'], ['aim_endpoint_groups.aim_id']),
-        sa.ForeignKeyConstraint(
-            ['vmm_type', 'vmm_name'],
-            ['aim_vmm_domains.type', 'aim_vmm_domains.name']))
+            ['epg_aim_id'], ['aim_endpoint_groups.aim_id']))
 
     op.create_table(
         'aim_endpoint_group_physical_domains',
@@ -62,9 +59,7 @@ def upgrade():
         sa.Column('physdom_name', sa.String(64), nullable=False),
         sa.PrimaryKeyConstraint('epg_aim_id', 'physdom_name'),
         sa.ForeignKeyConstraint(
-            ['epg_aim_id'], ['aim_endpoint_groups.aim_id']),
-        sa.ForeignKeyConstraint(
-            ['physdom_name'], ['aim_physical_domains.name']))
+            ['epg_aim_id'], ['aim_endpoint_groups.aim_id']))
 
 
 def downgrade():

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -176,12 +176,6 @@ class PhysicalDomain(model_base.Base, model_base.AttributeMixin):
 class EndpointGroupVMMDomain(model_base.Base):
     """DB model for Contracts used by EndpointGroup."""
     __tablename__ = 'aim_endpoint_group_vmm_domains'
-    __table_args__ = (
-        (sa.ForeignKeyConstraint(
-            ['vmm_type', 'vmm_name'],
-            ['aim_vmm_domains.type', 'aim_vmm_domains.name'],
-            name='fk_epg'),) +
-        to_tuple(model_base.Base.__table_args__))
 
     epg_aim_id = sa.Column(sa.Integer,
                            sa.ForeignKey('aim_endpoint_groups.aim_id'),
@@ -193,11 +187,6 @@ class EndpointGroupVMMDomain(model_base.Base):
 class EndpointGroupPhysicalDomain(model_base.Base):
     """DB model for Contracts used by EndpointGroup."""
     __tablename__ = 'aim_endpoint_group_physical_domains'
-    __table_args__ = (
-        (sa.ForeignKeyConstraint(
-            ['physdom_name'], ['aim_physical_domains.name'],
-            name='fk_epg'),) +
-        to_tuple(model_base.Base.__table_args__))
 
     epg_aim_id = sa.Column(sa.Integer,
                            sa.ForeignKey('aim_endpoint_groups.aim_id'),


### PR DESCRIPTION
There are some cases of pre-existing EPGs that have either physical
or virtual domains linked that don't exist in AIM.
Because AIM doesn't monitor infra objects yet, this could cause
a FK reference exception and the monitored object won't be created
properly.

Closes noironetworks/support#435