### PR TITLE
Allow owned RS objects within a monitored resource

### DIFF
--- a/aim/common/hashtree/structured_tree.py
+++ b/aim/common/hashtree/structured_tree.py
@@ -336,7 +336,6 @@ class StructuredHashTree(base.ComparableCollection):
         node.partial_hash = self._hash_attributes(key=key)
         node.full_hash = None
         node.dummy = True
-        node.metadata = None
         parents.append(node)
         # Cleanup parent list if node is a leaf
         self._clear_stack_from_dummies(parents)

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -787,7 +787,25 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self._observe_aci_events(current_config)
         # Observe
         agent._daemon_loop()
-
+        ext_net = self.aim_manager.get(self.ctx, ext_net)
+        self.assertEqual(['c1'], ext_net.provided_contract_names)
+        # Verify contract is provided in ACI
+        prov = test_aci_tenant.mock_get_data(
+            desired_monitor.serving_tenants[tenant_name].aci_session,
+            'mo/uni/tn-%s/out-default/instP-extnet/rsprov-c1' % tenant_name)
+        self.assertIsNotNone(prov[0])
+        # Also its tag exists
+        prov_tag = test_aci_tenant.mock_get_data(
+            desired_monitor.serving_tenants[tenant_name].aci_session,
+            'mo/uni/tn-%s/out-default/instP-extnet/rsprov-c1/'
+            'tag-openstack_aid' % tenant_name)
+        self.assertIsNotNone(prov_tag[0])
+        # Old contract still exists
+        prov_def = test_aci_tenant.mock_get_data(
+            desired_monitor.serving_tenants[tenant_name].aci_session,
+            'mo/uni/tn-%s/out-default/instP-extnet/rsprov-default' %
+            tenant_name)
+        self.assertIsNotNone(prov_def[0])
         # Verify all tree converged
         self._assert_universe_sync(desired_monitor, current_monitor)
         self._assert_universe_sync(desired_config, current_config)

--- a/aim/tests/unit/test_hashtree_db_listener.py
+++ b/aim/tests/unit/test_hashtree_db_listener.py
@@ -205,13 +205,15 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         for obj in [ap, epg2, epg]:
             self.assertEqual(aim_status.AciStatus.SYNC_FAILED,
                              self.mgr.get_status(self.ctx, obj).sync_status)
-        # Changing sync status of the EPG will bring everything back
-        epg = self.mgr.update(self.ctx, epg)
-        # All the objects are in synced state
-        for obj in [ap, epg2, epg]:
-            self.assertEqual(aim_status.AciStatus.SYNC_PENDING,
-                             self.mgr.get_status(self.ctx, obj).sync_status)
+
         if not monitored:
+            # Changing sync status of the EPG will bring everything back
+            epg = self.mgr.update(self.ctx, epg)
+            # All the objects are in synced state
+            for obj in [ap, epg2, epg]:
+                self.assertEqual(
+                    aim_status.AciStatus.SYNC_PENDING,
+                    self.mgr.get_status(self.ctx, obj).sync_status)
             empty_tree = self.tt_mgr.get(
                 self.ctx, tn_name, tree=empty_map[monitored])
             configured_tree = self.tt_mgr.get(


### PR DESCRIPTION
In certain cases, like external networks, we need to add some RS
items, like provided/consumed contracts, in a monitored object.
Achieve this by not setting monitored objects in pending state
if updates other than the monitored flag itself happen.
Also, share some of the relevant tree building code between AIM and
AID.