### PR TITLE
Improve status management and K8S watcher reliability

### DIFF
--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -31,8 +31,8 @@ from aim.agent.aid.universes.aci import error
 from aim.agent.aid.universes import base_universe
 from aim.common.hashtree import structured_tree
 from aim.common import utils
-from aim.db import hashtree_db_listener
 from aim import exceptions
+from aim import tree_manager
 
 LOG = logging.getLogger(__name__)
 TENANT_KEY = 'fvTenant'
@@ -155,7 +155,7 @@ class AciTenantManager(gevent.Greenlet):
         self.to_aim_converter = converter.AciToAimModelConverter()
         self.to_aci_converter = converter.AimToAciModelConverter()
         self.object_backlog = Queue.Queue()
-        self.tree_builder = hashtree_db_listener.HashTreeBuilder(None)
+        self.tree_builder = tree_manager.HashTreeBuilder(None)
         self.tag_name = aim_system_id or self.apic_config.get_option(
             'aim_system_id', 'aim')
         self.tag_set = set()

--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -190,6 +190,11 @@ class AimManager(object):
                             raise exc.InvalidMonitoredObjectDelete(
                                 object=resource)
                     # Recursively delete monitored children
+                    # REVISIT(ivar): In a FK-free world, this would
+                    # not be necessary. The Monitored universe would take care
+                    # of deleting these parentless objects eventually. Have we
+                    # actually undermined the purpose of AIM by adding FK
+                    # constraints to the SQLAlchemy backend?
                     for child_res in self._iter_children(context, resource,
                                                          monitored=True):
                         self.delete(context, child_res)
@@ -307,7 +312,7 @@ class AimManager(object):
                     context, resource, api_status.AciStatus.SYNC_PENDING,
                     exclude=[api_status.AciStatus.SYNCED,
                              api_status.AciStatus.SYNC_PENDING]
-                    if not top else []):
+                    if not top else [api_status.AciStatus.SYNC_PENDING]):
                 # Change parent first
                 parent_klass = resource._tree_parent
                 if parent_klass:

--- a/aim/api/status.py
+++ b/aim/api/status.py
@@ -48,7 +48,7 @@ class AciStatus(resource.ResourceBase, OperationalResource):
         ('resource_type', t.string()),
         ('resource_id', t.id))
     other_attributes = t.other(
-        ('sync_status', t.enum(SYNCED, SYNC_PENDING, SYNC_FAILED, None)),
+        ('sync_status', t.enum(SYNCED, SYNC_PENDING, SYNC_FAILED)),
         ('sync_message', t.string()),
         ('health_score', t.number),
         ('faults', t.list_of_strings))
@@ -62,7 +62,7 @@ class AciStatus(resource.ResourceBase, OperationalResource):
     def __init__(self, **kwargs):
         super(AciStatus, self).__init__({'resource_type': None,
                                          'resource_id': None,
-                                         'sync_status': None,
+                                         'sync_status': self.SYNC_PENDING,
                                          'sync_message': '',
                                          'health_score': 100,
                                          'faults': []}, **kwargs)

--- a/aim/db/hashtree_db_listener.py
+++ b/aim/db/hashtree_db_listener.py
@@ -13,8 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import copy
-
 from oslo_log import log as logging
 
 from aim.api import status as aim_status
@@ -28,122 +26,6 @@ from aim import tree_manager
 LOG = logging.getLogger(__name__)
 
 
-class HashTreeBuilder(object):
-    CONFIG = 'config'
-    OPER = 'oper'
-    MONITOR = 'monitor'
-
-    def __init__(self, aim_manager):
-        self.aim_manager = aim_manager
-        self.tt_maker = tree_manager.AimHashTreeMaker()
-
-    def build(self, added, updated, deleted, tree_map, aim_ctx=None):
-        """Build hash tree
-
-        :param updated: list of AIM objects
-        :param deleted: list of AIM objects
-        :param tree_map: map of trees by type and tenant
-        eg: {'config': {'tn1': <tenant hashtree>}}
-        :return: tree updates
-        """
-
-        # Segregate updates by tenant
-        updates_by_tenant = {}
-        all_updates = [added, updated, deleted]
-        conf = aim_tree.ConfigTenantTree
-        monitor = aim_tree.MonitoredTenantTree
-        oper = aim_tree.OperationalTenantTree
-        for idx in range(len(all_updates)):
-            tree_index = 0 if idx < 2 else 1
-            for res in all_updates[idx]:
-                if isinstance(res, aim_status.AciStatus) and aim_ctx:
-                    parent = self.aim_manager.get_by_id(
-                        aim_ctx, res.parent_class, res.resource_id)
-                    # Remove main object from config tree if in sync error
-                    # during an update
-                    if tree_index == 0:
-                        if res.sync_status == res.SYNC_FAILED:
-                            parent = self.aim_manager.get_by_id(
-                                aim_ctx, res.parent_class, res.resource_id)
-                            # Put the object in error state
-                            parent._error = True
-                            all_updates[1].append(parent)
-                        elif res.sync_status == res.SYNC_PENDING:
-                            # A sync pending monitored object is in a limbo
-                            # state, potentially switching from Owned to
-                            # Monitored, and therefore should be removed from
-                            # all the trees
-                            if parent.monitored:
-                                all_updates[-1].append(parent)
-                            else:
-                                all_updates[1].append(parent)
-                        elif res.sync_status == res.SYNCED:
-                            all_updates[1].append(parent)
-                    else:
-                        if parent:
-                            # Delete parent on operational tree
-                            parent_key = self.tt_maker.get_tenant_key(parent)
-                            updates_by_tenant.setdefault(
-                                parent_key, {conf: ([], []), monitor: ([], []),
-                                             oper: ([], [])})
-                            updates_by_tenant[
-                                parent_key][oper][tree_index].append(parent)
-                key = self.tt_maker.get_tenant_key(res)
-                if not key:
-                    continue
-                updates_by_tenant.setdefault(
-                    key, {conf: ([], []), monitor: ([], []), oper: ([], [])})
-                if isinstance(res, aim_status.AciFault):
-                    # Operational Tree
-                    updates_by_tenant[key][oper][tree_index].append(res)
-                else:
-                    if getattr(res, 'monitored', None):
-                        # Monitored Tree
-                        res_copy = copy.deepcopy(res)
-                        updates_by_tenant[key][monitor][tree_index].append(
-                            res_copy)
-                        # Don't modify the original resource in a visible
-                        # way
-                        res = copy.deepcopy(res)
-                        # Fake this as pre-existing
-                        res.pre_existing = True
-                        res.monitored = False
-                    # Configuration Tree
-                    updates_by_tenant[key][conf][tree_index].append(res)
-
-        upd_trees, udp_op_trees, udp_mon_trees = [], [], []
-        for tenant, upd in updates_by_tenant.iteritems():
-            ttree = tree_map[self.CONFIG][tenant]
-            ttree_operational = tree_map[self.OPER][tenant]
-            ttree_monitor = tree_map[self.MONITOR][tenant]
-            # Update Configuration Tree
-            self.tt_maker.update(ttree, upd[conf][0])
-            self.tt_maker.delete(ttree, upd[conf][1])
-            # Clear new monitored objects
-            self.tt_maker.clear(ttree, upd[monitor][0])
-
-            # Update Operational Tree
-            self.tt_maker.update(ttree_operational, upd[oper][0])
-            self.tt_maker.delete(ttree_operational, upd[oper][1])
-            # Delete operational resources as well
-            self.tt_maker.delete(ttree_operational, upd[conf][1])
-            self.tt_maker.delete(ttree_operational, upd[monitor][1])
-
-            # Update Monitored Tree
-            self.tt_maker.update(ttree_monitor, upd[monitor][0])
-            self.tt_maker.delete(ttree_monitor, upd[monitor][1])
-            # Clear new owned objects
-            self.tt_maker.clear(ttree_monitor, upd[conf][0])
-
-            if ttree.root_key:
-                upd_trees.append(ttree)
-            if ttree_operational.root_key:
-                udp_op_trees.append(ttree_operational)
-            if ttree_monitor.root_key:
-                udp_mon_trees.append(ttree_monitor)
-        return upd_trees, udp_op_trees, udp_mon_trees
-
-
 class HashTreeDbListener(object):
     """Updates persistent hash-tree in response to DB updates."""
 
@@ -151,7 +33,7 @@ class HashTreeDbListener(object):
         self.aim_manager = aim_manager
         self.tt_mgr = tree_manager.TenantHashTreeManager()
         self.tt_maker = tree_manager.AimHashTreeMaker()
-        self.tt_builder = HashTreeBuilder(self.aim_manager)
+        self.tt_builder = tree_manager.HashTreeBuilder(self.aim_manager)
         self.store = store
 
     def on_commit(self, session, added, updated, deleted, curr_cfg=None,

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -35,6 +35,7 @@ from aim import context
 from aim.db import api
 from aim.db import model_base
 from aim.tools.cli import shell  # noqa
+from aim import tree_manager
 
 CONF = cfg.CONF
 ROOTDIR = os.path.dirname(__file__)
@@ -126,7 +127,7 @@ def _k8s_post_create(self, created):
         w._reset_trees = mock.Mock()
         w._observer_loop()
         w.warmup_time = -1
-        w._builder_loop()
+        w._persistence_loop()
 
 
 def _k8s_post_delete(self, deleted):
@@ -138,7 +139,7 @@ def _k8s_post_delete(self, deleted):
         w._reset_trees = mock.Mock()
         w._observer_loop()
         w.warmup_time = -1
-        w._builder_loop()
+        w._persistence_loop()
 
 
 class TestAimDBBase(BaseTestCase):
@@ -182,6 +183,7 @@ class TestAimDBBase(BaseTestCase):
         self.store = api.get_store(expire_on_commit=True)
         self.ctx = context.AimContext(store=self.store)
         self.cfg_manager = aim_cfg.ConfigManager(self.ctx, '')
+        self.tt_mgr = tree_manager.TenantHashTreeManager()
         resource.ResourceBase.__eq__ = resource_equal
         self.cfg_manager.replace_all(CONF)
         self.sys_id = self.cfg_manager.get_option('aim_system_id', 'aim')

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -1337,8 +1337,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
             result[tenant.name] = {}
             for type in tree_manager.SUPPORTED_TREES:
                 result[tenant.name][type] = (
-                    self.ctx.store._hashtree_db_listener.tt_mgr.get(
-                        self.ctx, tenant.name, tree=type))
+                    self.tt_mgr.get(self.ctx, tenant.name, tree=type))
         return result
 
     def _sync_and_verify(self, agent, to_observe, couples):

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -254,11 +254,10 @@ class TestResourceOpsBase(object):
         status = self.mgr.get_status(self.ctx, res)
         if status:
             initial_status = copy.deepcopy(status)
-            initial_status.sync_status = None
+            initial_status.id = None
             exp_calls = [
                 mock.call(mock.ANY, [res], [], []),
-                mock.call(mock.ANY, [initial_status], [], []),
-                mock.call(mock.ANY, [], [status, res], [])]
+                mock.call(mock.ANY, [initial_status], [res], [])]
             self._check_call_list(exp_calls, listener)
         else:
             listener.assert_called_with(mock.ANY, [res], [], [])
@@ -270,8 +269,7 @@ class TestResourceOpsBase(object):
             status = self.mgr.get_status(self.ctx, res)
             if status:
                 exp_calls = [
-                    mock.call(mock.ANY, [], [res], []),
-                    mock.call(mock.ANY, [], [status, res], [])]
+                    mock.call(mock.ANY, [], [res], [])]
                 self._check_call_list(exp_calls, listener)
             else:
                 # TODO(ivar): Agent object gets 2 calls to the hook on an

--- a/aim/tests/unit/test_hashtree_db_listener.py
+++ b/aim/tests/unit/test_hashtree_db_listener.py
@@ -22,6 +22,7 @@ from aim.api import resource as aim_res
 from aim.api import status as aim_status
 from aim.common.hashtree import structured_tree as tree
 from aim.db import agent_model      # noqa
+from aim.db import hashtree_db_listener as ht_db_l
 from aim.tests import base
 from aim import tree_manager
 
@@ -32,7 +33,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         super(TestHashTreeDbListener, self).setUp()
         self.tt_mgr = tree_manager.TenantHashTreeManager()
         self.mgr = aim_manager.AimManager()
-        self.db_l = self.ctx.store._hashtree_db_listener
+        self.db_l = ht_db_l.HashTreeDbListener(aim_manager.AimManager(),
+                                               self.ctx.store)
 
     def _test_resource_ops(self, resource, tenant, tree_objects,
                            tree_objects_update,

--- a/aim/tree_manager.py
+++ b/aim/tree_manager.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import copy
 import traceback
 
 from oslo_log import log as logging
@@ -413,3 +414,119 @@ class TenantHashTreeManager(TenantTreeManager):
             structured_tree.StructuredHashTree,
             AimHashTreeMaker.tenant_rn_funct,
             AimHashTreeMaker.tenant_key_funct)
+
+
+class HashTreeBuilder(object):
+    CONFIG = 'config'
+    OPER = 'oper'
+    MONITOR = 'monitor'
+
+    def __init__(self, aim_manager):
+        self.aim_manager = aim_manager
+        self.tt_maker = AimHashTreeMaker()
+
+    def build(self, added, updated, deleted, tree_map, aim_ctx=None):
+        """Build hash tree
+
+        :param updated: list of AIM objects
+        :param deleted: list of AIM objects
+        :param tree_map: map of trees by type and tenant
+        eg: {'config': {'tn1': <tenant hashtree>}}
+        :return: tree updates
+        """
+
+        # Segregate updates by tenant
+        updates_by_tenant = {}
+        all_updates = [added, updated, deleted]
+        conf = CONFIG_TREE
+        monitor = MONITORED_TREE
+        oper = OPERATIONAL_TREE
+        for idx in range(len(all_updates)):
+            tree_index = 0 if idx < 2 else 1
+            for res in all_updates[idx]:
+                if isinstance(res, aim_status.AciStatus) and aim_ctx:
+                    parent = self.aim_manager.get_by_id(
+                        aim_ctx, res.parent_class, res.resource_id)
+                    # Remove main object from config tree if in sync error
+                    # during an update
+                    if tree_index == 0:
+                        if res.sync_status == res.SYNC_FAILED:
+                            parent = self.aim_manager.get_by_id(
+                                aim_ctx, res.parent_class, res.resource_id)
+                            # Put the object in error state
+                            parent._error = True
+                            all_updates[1].append(parent)
+                        elif res.sync_status == res.SYNC_PENDING:
+                            # A sync pending monitored object is in a limbo
+                            # state, potentially switching from Owned to
+                            # Monitored, and therefore should be removed from
+                            # all the trees
+                            if parent.monitored:
+                                all_updates[-1].append(parent)
+                            else:
+                                all_updates[1].append(parent)
+                        elif res.sync_status == res.SYNCED:
+                            all_updates[1].append(parent)
+                    else:
+                        if parent:
+                            # Delete parent on operational tree
+                            parent_key = self.tt_maker.get_tenant_key(parent)
+                            updates_by_tenant.setdefault(
+                                parent_key, {conf: ([], []), monitor: ([], []),
+                                             oper: ([], [])})
+                            updates_by_tenant[
+                                parent_key][oper][tree_index].append(parent)
+                key = self.tt_maker.get_tenant_key(res)
+                if not key:
+                    continue
+                updates_by_tenant.setdefault(
+                    key, {conf: ([], []), monitor: ([], []), oper: ([], [])})
+                if isinstance(res, aim_status.AciFault):
+                    # Operational Tree
+                    updates_by_tenant[key][oper][tree_index].append(res)
+                else:
+                    if getattr(res, 'monitored', None):
+                        # Monitored Tree
+                        res_copy = copy.deepcopy(res)
+                        updates_by_tenant[key][monitor][tree_index].append(
+                            res_copy)
+                        # Don't modify the original resource in a visible
+                        # way
+                        res = copy.deepcopy(res)
+                        # Fake this as pre-existing
+                        res.pre_existing = True
+                        res.monitored = False
+                    # Configuration Tree
+                    updates_by_tenant[key][conf][tree_index].append(res)
+
+        upd_trees, udp_op_trees, udp_mon_trees = [], [], []
+        for tenant, upd in updates_by_tenant.iteritems():
+            ttree = tree_map[self.CONFIG][tenant]
+            ttree_operational = tree_map[self.OPER][tenant]
+            ttree_monitor = tree_map[self.MONITOR][tenant]
+            # Update Configuration Tree
+            self.tt_maker.update(ttree, upd[conf][0])
+            self.tt_maker.delete(ttree, upd[conf][1])
+            # Clear new monitored objects
+            self.tt_maker.clear(ttree, upd[monitor][0])
+
+            # Update Operational Tree
+            self.tt_maker.update(ttree_operational, upd[oper][0])
+            self.tt_maker.delete(ttree_operational, upd[oper][1])
+            # Delete operational resources as well
+            self.tt_maker.delete(ttree_operational, upd[conf][1])
+            self.tt_maker.delete(ttree_operational, upd[monitor][1])
+
+            # Update Monitored Tree
+            self.tt_maker.update(ttree_monitor, upd[monitor][0])
+            self.tt_maker.delete(ttree_monitor, upd[monitor][1])
+            # Clear new owned objects
+            self.tt_maker.clear(ttree_monitor, upd[conf][0])
+
+            if ttree.root_key:
+                upd_trees.append(ttree)
+            if ttree_operational.root_key:
+                udp_op_trees.append(ttree_operational)
+            if ttree_monitor.root_key:
+                udp_mon_trees.append(ttree_monitor)
+        return upd_trees, udp_op_trees, udp_mon_trees


### PR DESCRIPTION
- Empty sync_status doesn't exist anymore, sync_pending will be
  the default;
- Observer thread in K8S will now also build the hashtree. Errors
  in building the hashtree will result in status reset instead of
  information loss;
- Move TreeBuilder in the tree_manager module, since it's not DB
  specific;