### PR TITLE
Ensure ACI cross version compatibility

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -174,6 +174,9 @@ class AciUniverse(base.HashTreeStoredUniverse):
         super(AciUniverse, self).initialize(store, conf_mgr)
         self._aim_converter = converter.AciToAimModelConverter()
         self.aci_session = self.establish_aci_session(self.conf_manager)
+        # Initialize children MOS here so that it globally fails if there's
+        # any bug or network partition.
+        aci_tenant.get_children_mos(self.aci_session)
         self.ws_context = get_websocket_context(self.conf_manager)
         self.aim_system_id = self.conf_manager.get_option('aim_system_id',
                                                           'aim')

--- a/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
@@ -367,6 +367,10 @@ class TestAciClientMixin(object):
             'apicapi.apic_client.ApicSession.DELETE')
         self.delete.start()
 
+        self.get = mock.patch(
+            'apicapi.apic_client.ApicSession.GET')
+        self.get.start()
+
         self.apic_login = mock.patch(
             'apicapi.apic_client.ApicSession.login')
         self.apic_login.start()
@@ -381,6 +385,7 @@ class TestAciClientMixin(object):
         self.addCleanup(self.process_q.stop)
         self.addCleanup(self.post_body.stop)
         self.addCleanup(self.delete.stop)
+        self.addCleanup(self.get.stop)
         self.addCleanup(self.monitors.stop)
 
 


### PR DESCRIPTION
To avoid websocket subscription errors on older version of ACI,
test all the managed object classes to see whether they are
supported.