### PR TITLE
Always set classPref in fvRsDomAtt objects

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -253,8 +253,10 @@ def fv_rs_dom_att_converter(object_dict, otype, helper,
             dn = default_identity_converter(
                 object_dict, otype, helper, extra_attributes=[phys_dn],
                 aci_mo_type='fvRsDomAtt', to_aim=False)[0]
-            result.append({'fvRsDomAtt': {'attributes': {'dn': dn,
-                                                         'tDn': phys_dn}}})
+            result.append({'fvRsDomAtt': {'attributes':
+                                          {'dn': dn,
+                                           'tDn': phys_dn,
+                                           'classPref': 'useg'}}})
         # Convert OpenStack VMMs
         for vmm in object_dict['openstack_vmm_domain_names']:
             # Get VMM DN
@@ -266,8 +268,10 @@ def fv_rs_dom_att_converter(object_dict, otype, helper,
             dn = default_identity_converter(
                 object_dict, otype, helper, extra_attributes=[vmm_dn],
                 aci_mo_type='fvRsDomAtt', to_aim=False)[0]
-            result.append({'fvRsDomAtt': {'attributes': {'dn': dn,
-                                                         'tDn': vmm_dn}}})
+            result.append({'fvRsDomAtt': {'attributes':
+                                          {'dn': dn,
+                                           'tDn': vmm_dn,
+                                           'classPref': 'useg'}}})
     return result
 
 

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1055,17 +1055,20 @@ class TestAimToAciConverterEPG(TestAimToAciConverterBase, base.TestAimDBBase):
                 'attributes': {
                     'dn': 'uni/tn-t1/ap-a1/epg-test-1/'
                           'rsdomAtt-[uni/phys-phys]',
-                    'tDn': 'uni/phys-phys'}}}, {
+                    'tDn': 'uni/phys-phys',
+                    'classPref': 'useg'}}}, {
             'fvRsDomAtt': {
                 'attributes': {
                     'dn': 'uni/tn-t1/ap-a1/epg-test-1/'
                           'rsdomAtt-[uni/vmmp-OpenStack/dom-op]',
-                    'tDn': 'uni/vmmp-OpenStack/dom-op'}}}, {
+                    'tDn': 'uni/vmmp-OpenStack/dom-op',
+                    'classPref': 'useg'}}}, {
             'fvRsDomAtt': {
                 'attributes': {
                     'dn': 'uni/tn-t1/ap-a1/epg-test-1/'
                           'rsdomAtt-[uni/vmmp-OpenStack/dom-op2]',
-                    'tDn': 'uni/vmmp-OpenStack/dom-op2'}}},
+                    'tDn': 'uni/vmmp-OpenStack/dom-op2',
+                    'classPref': 'useg'}}},
             _aci_obj('fvRsPathAtt',
                      dn='uni/tn-t1/ap-a1/epg-test-1/rspathAtt-'
                         '[topology/pod-1/paths-202/pathep-[eth1/7]]',

--- a/aim/tools/cli/commands/db_migration.py
+++ b/aim/tools/cli/commands/db_migration.py
@@ -22,6 +22,7 @@ from aim import aim_manager
 from aim.api import resource
 from aim import context
 from aim.db import api
+from aim.db import hashtree_db_listener
 from aim.db import migration
 from aim.db.migration import alembic_migrations
 from aim.tools.cli.groups import aimcli
@@ -62,6 +63,11 @@ def upgrade(ctx, version):
     common_tenant = resource.Tenant(name='common', monitored=True)
     if not aim_mgr.get(aim_ctx, common_tenant):
         aim_mgr.create(aim_ctx, common_tenant)
+
+    click.echo('Rebuilding hash-trees')
+    # reset hash-trees to account for schema/converter changes
+    listener = hashtree_db_listener.HashTreeDbListener(aim_mgr, aim_ctx.store)
+    listener.reset()
 
 
 @db_migration.command(name='stamp')


### PR DESCRIPTION
The classPref is set to 'useg' to allow micro-
segmentation EPGs. This should not affect other
EPGs that don't use micro-segmentation.

Also db-migration now does an implicit hash-tree
reset to account for schema and converter changes.

Signed-off-by: Amit Bose <amitbose@gmail.com>