### PR TITLE
Fix session modification in DB-listener

### DIFF
--- a/aim/common/utils.py
+++ b/aim/common/utils.py
@@ -155,10 +155,6 @@ def retry_loop(max_wait, max_retries, name):
 
 class FakeContext(object):
 
-    def __init__(self, session=None, store=None):
-        if session:
-            self.db_session = session
+    def __init__(self, store=None):
         if store:
             self.store = store
-            if session:
-                self.store.db_session = session

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -474,9 +474,8 @@ class TestAciResourceOpsBase(TestResourceOpsBase):
         self.mgr.create(self.ctx, res)
 
         old = self._get_hash_trees()
-        listener = hashtree_db_listener.HashTreeDbListener(self.mgr,
-                                                           self.ctx.store)
-        listener.reset()
+        listener = hashtree_db_listener.HashTreeDbListener(self.mgr)
+        listener.reset(self.ctx.store)
         new = self._get_hash_trees()
         self.assertEqual(old, new)
 

--- a/aim/tests/unit/test_hashtree_db_listener.py
+++ b/aim/tests/unit/test_hashtree_db_listener.py
@@ -21,7 +21,7 @@ from aim import aim_manager
 from aim.api import resource as aim_res
 from aim.api import status as aim_status
 from aim.common.hashtree import structured_tree as tree
-from aim.db import agent_model      # noqa
+from aim.db import agent_model  # noqa
 from aim.db import hashtree_db_listener as ht_db_l
 from aim.tests import base
 from aim import tree_manager
@@ -33,14 +33,13 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         super(TestHashTreeDbListener, self).setUp()
         self.tt_mgr = tree_manager.TenantHashTreeManager()
         self.mgr = aim_manager.AimManager()
-        self.db_l = ht_db_l.HashTreeDbListener(aim_manager.AimManager(),
-                                               self.ctx.store)
+        self.db_l = ht_db_l.HashTreeDbListener(aim_manager.AimManager())
 
     def _test_resource_ops(self, resource, tenant, tree_objects,
                            tree_objects_update,
                            tree_type=tree_manager.CONFIG_TREE, **updates):
         # add
-        self.db_l.on_commit(self.ctx.db_session, [resource], [], [])
+        self.db_l.on_commit(self.ctx.store, [resource], [], [])
 
         db_tree = self.tt_mgr.get(self.ctx, tenant, tree=tree_type)
         exp_tree = tree.StructuredHashTree().include(tree_objects)
@@ -48,14 +47,14 @@ class TestHashTreeDbListener(base.TestAimDBBase):
 
         # update
         resource.__dict__.update(**updates)
-        self.db_l.on_commit(self.ctx.db_session, [], [resource], [])
+        self.db_l.on_commit(self.ctx.store, [], [resource], [])
 
         db_tree = self.tt_mgr.get(self.ctx, tenant, tree=tree_type)
         exp_tree = tree.StructuredHashTree().include(tree_objects_update)
         self.assertEqual(exp_tree, db_tree)
 
         # delete
-        self.db_l.on_commit(self.ctx.db_session, [], [], [resource])
+        self.db_l.on_commit(self.ctx.store, [], [], [resource])
         db_tree = self.tt_mgr.get(self.ctx, tenant, tree=tree_type)
         exp_tree = tree.StructuredHashTree()
         self.assertEqual(exp_tree, db_tree)

--- a/aim/tools/cli/commands/db_migration.py
+++ b/aim/tools/cli/commands/db_migration.py
@@ -66,8 +66,8 @@ def upgrade(ctx, version):
 
     click.echo('Rebuilding hash-trees')
     # reset hash-trees to account for schema/converter changes
-    listener = hashtree_db_listener.HashTreeDbListener(aim_mgr, aim_ctx.store)
-    listener.reset()
+    listener = hashtree_db_listener.HashTreeDbListener(aim_mgr)
+    listener.reset(aim_ctx.store)
 
 
 @db_migration.command(name='stamp')

--- a/aim/tools/cli/debug/hashtree.py
+++ b/aim/tools/cli/debug/hashtree.py
@@ -75,5 +75,5 @@ def reset(ctx, tenant):
 def _reset(ctx, tenant):
     mgr = ctx.obj['manager']
     aim_ctx = ctx.obj['aim_ctx']
-    listener = hashtree_db_listener.HashTreeDbListener(mgr, aim_ctx.store)
-    listener.reset(tenant)
+    listener = hashtree_db_listener.HashTreeDbListener(mgr)
+    listener.reset(aim_ctx.store, tenant)

--- a/aim/tree_manager.py
+++ b/aim/tree_manager.py
@@ -207,7 +207,7 @@ class TenantTreeManager(object):
         # TODO(ivar): this is sqlAlchemy specific. find a cleaner way to manage
         # tree manager's hooks.
         if context.store.supports_hooks:
-            session = context.db_session
+            session = context.store.db_session
             if not sa_event.contains(session, 'after_flush',
                                      self._after_session_flush):
                 sa_event.listen(session, 'after_flush',


### PR DESCRIPTION
Use of FakeContext in hash-tree listener was
causing inadvertent modification of the DB
session associated with a store. This fix
avoids that modification and also cleans up
HashTreeDbListener a bit.

Closes noironetworks/support#505

Signed-off-by: Amit Bose <amitbose@gmail.com>