### PR TITLE
Force sync status change for monitored objects

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -374,6 +374,9 @@ class AciUniverse(base.HashTreeStoredUniverse):
             return data.tenant_name
 
     def get_resources_for_delete(self, resource_keys):
+        if resource_keys:
+            LOG.debug("Requesting resource keys in ACI Universe for "
+                      "delete: %s", resource_keys)
         result = []
         for key in resource_keys:
             key_parts = self._split_key(key)
@@ -395,6 +398,9 @@ class AciUniverse(base.HashTreeStoredUniverse):
                     aci_type = 'tagInst'
                     dn = dn + '/tag-' + self.aim_system_id
             result.append({aci_type: {'attributes': {'dn': dn}}})
+        if resource_keys:
+            LOG.debug("Result for keys %s\n in ACI Universe for delete:\n %s" %
+                      (resource_keys, result))
         return result
 
     def _get_state_copy(self, tenant):

--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -129,7 +129,9 @@ class AimManager(object):
                 # should not go in pending.
                 if self._should_set_pending(old_db_obj, old_monitored,
                                             new_monitored):
-                    self.set_resource_sync_pending(context, resource)
+                    self.set_resource_sync_pending(
+                        context, resource,
+                        force=getattr(db_obj, 'monitored', False))
             return self.get(context, resource)
 
     @utils.log
@@ -162,7 +164,9 @@ class AimManager(object):
                     # status should not go in pending.
                     if self._should_set_pending(db_obj, old_monitored,
                                                 new_monitored):
-                        self.set_resource_sync_pending(context, resource)
+                        self.set_resource_sync_pending(
+                            context, resource,
+                            force=getattr(db_obj, 'monitored', False))
                 return self.get(context, resource)
 
     def _should_set_pending(self, old_obj, old_monitored, new_monitored):
@@ -302,7 +306,8 @@ class AimManager(object):
     def set_resource_sync_synced(self, context, resource):
         self._set_resource_sync(context, resource, api_status.AciStatus.SYNCED)
 
-    def set_resource_sync_pending(self, context, resource, top=True):
+    def set_resource_sync_pending(self, context, resource, top=True,
+                                  force=False):
         # When a resource goes in pending state, propagate to both parent
         # and subtree
         with context.store.begin(subtransactions=True):
@@ -312,7 +317,8 @@ class AimManager(object):
                     context, resource, api_status.AciStatus.SYNC_PENDING,
                     exclude=[api_status.AciStatus.SYNCED,
                              api_status.AciStatus.SYNC_PENDING]
-                    if not top else [api_status.AciStatus.SYNC_PENDING]):
+                    if not top else [api_status.AciStatus.SYNC_PENDING] if not
+                    force else []):
                 # Change parent first
                 parent_klass = resource._tree_parent
                 if parent_klass:

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -193,7 +193,7 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         objs = [
             self._get_example_aci_fault(),
             self._get_example_aci_bd(),
-            {'vzSubj': {'attributes': {'dn': u'uni/tn-t1/brc-c/subj-s'}}},
+            {'vzSubj': {'attributes': {'dn': 'uni/tn-t1/brc-c/subj-s'}}},
             {'vzInTerm': {'attributes': {
                 'dn': 'uni/tn-t1/brc-c/subj-s/intmnl'}}},
             {'vzOutTerm': {'attributes': {

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -1004,7 +1004,11 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
             desired_monitor.serving_tenants[tenant_name].aci_session,
             'mo/' + epg.dn + '/rsprov-c/tag-openstack_aid')
         self.assertIsNotNone(tag)
-
+        # Run an empty change on the EPG, bringing it to sync pending
+        self.aim_manager.update(self.ctx, epg)
+        self._sync_and_verify(agent, current_config,
+                              [(desired_config, current_config),
+                               (desired_monitor, current_monitor)])
         # Put back EPG into monitored state
         epg = self.aim_manager.update(self.ctx, epg, monitored=True)
         self.assertTrue(epg.monitored)


### PR DESCRIPTION
For optimization purposes, we don't fire DB calls to update a status
that is not changing compared to the previous version. For managed
objects transitioning to monitored however this could be critical,
as the Hashtree builder expects a status update in order to remove
the nodes from all the trees.