### PR TITLE
Manage object status asynchronously

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -435,6 +435,10 @@ class AciUniverse(base.HashTreeStoredUniverse):
             sign_hash=apic_config.get_option(
                 'signature_hash_type', group='apic'))
 
+    def update_status_objects(self, my_state, other_state, other_universe,
+                              raw_diff, transformed_diff):
+        pass
+
 
 class AciOperationalUniverse(AciUniverse):
     """ACI Universe for operational state."""

--- a/aim/agent/aid/universes/aci/converters/utils.py
+++ b/aim/agent/aid/universes/aci/converters/utils.py
@@ -77,7 +77,7 @@ def default_attribute_converter(object_dict, attribute,
 
 def default_to_resource(converted, helper, to_aim=True):
     klass = helper['resource']
-    default_skip = ['preExisting', 'monitored']
+    default_skip = ['preExisting', 'monitored', 'Error', 'Pending']
     skip = helper.get('skip', [])
     if to_aim:
         # APIC to AIM

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -69,7 +69,7 @@ class ResourceBase(object):
     @property
     def members(self):
         return {x: self.__dict__[x] for x in self.attributes() +
-                ['pre_existing'] + ['_error'] if x in self.__dict__}
+                ['pre_existing', '_error', '_pending'] if x in self.__dict__}
 
     def __str__(self):
         return '%s(%s)' % (type(self).__name__, ','.join(self.identity))

--- a/aim/api/status.py
+++ b/aim/api/status.py
@@ -46,6 +46,7 @@ class AciStatus(resource.ResourceBase, OperationalResource):
     SYNCED = 'synced'
     # Create/update of ACI object failed
     SYNC_FAILED = 'sync_failed'
+    SYNC_NA = 'N/A'
 
     identity_attributes = t.identity(
         ('resource_type', t.string()),
@@ -66,7 +67,7 @@ class AciStatus(resource.ResourceBase, OperationalResource):
     def __init__(self, **kwargs):
         super(AciStatus, self).__init__({'resource_type': None,
                                          'resource_id': None,
-                                         'sync_status': self.SYNC_PENDING,
+                                         'sync_status': self.SYNC_NA,
                                          'sync_message': '',
                                          'health_score': 100,
                                          'faults': []}, **kwargs)

--- a/aim/common/hashtree/base.py
+++ b/aim/common/hashtree/base.py
@@ -170,6 +170,10 @@ class OrderedList(object):
         except KeyError:
             return default
 
+    def update(self, iterable):
+        for item in iterable:
+            self.add(item)
+
     def __str__(self):
         return "[" + ",".join("%s" % x for x in self._stash) + "]"
 

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -236,10 +236,14 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         result = self.universe.get_resources_for_delete(keys)
         self.assertEqual(sorted(objs), sorted(result))
         # Create a pending monitored object
-        self.universe.manager.create(self.ctx, resource.Tenant(name='tn1',
-                                                               monitored=True))
-        self.universe.manager.create(self.ctx, resource.BridgeDomain(
-            tenant_name='tn1', name='monitoredBD', monitored=True))
+        tn1 = resource.Tenant(name='tn1', monitored=True)
+        monitored_bd = resource.BridgeDomain(
+            tenant_name='tn1', name='monitoredBD', monitored=True)
+        self.universe.manager.create(self.ctx, tn1)
+        self.universe.manager.set_resource_sync_pending(self.ctx, tn1)
+        self.universe.manager.create(self.ctx, monitored_bd)
+        self.universe.manager.set_resource_sync_pending(self.ctx, monitored_bd)
+
         result = self.universe.get_resources_for_delete(
             [('fvTenant|tn1', 'fvBD|monitoredBD')])
         self.assertEqual(1, len(result))

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -319,10 +319,6 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.aim_manager.create(self.ctx, bd1_tn1)
         bd1_tn1_status = self.aim_manager.get_status(self.ctx, bd1_tn1)
         bd1_tn2_status = self.aim_manager.get_status(self.ctx, bd1_tn2)
-        self.assertEqual(aim_status.AciStatus.SYNC_PENDING,
-                         bd1_tn1_status.sync_status)
-        self.assertEqual(aim_status.AciStatus.SYNC_PENDING,
-                         bd1_tn2_status.sync_status)
         self.aim_manager.set_fault(
             self.ctx, bd1_tn1, aim_status.AciFault(
                 fault_code='516',
@@ -516,6 +512,11 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
 
         # Run the loop for reconciliation
         agent._daemon_loop()
+
+        # Run loop again to set SYNCED state
+        self._observe_aci_events(current_config)
+        agent._daemon_loop()
+
         # A monitored BD should now exist in AIM
         aim_bd = self.aim_manager.get(self.ctx, resource.BridgeDomain(
             tenant_name=tenant_name, name='default'))

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -300,7 +300,9 @@ class TestResourceOpsBase(object):
         self.mgr.create(self.ctx, res, overwrite=True)
         status = self.mgr.get_status(self.ctx, res)
         self.assertTrue(isinstance(status, aim_status.AciStatus))
-        self.assertTrue(status.is_build())
+        # Sync status not available
+        self.assertEqual(status.SYNC_NA, status.sync_status)
+        self.assertFalse(status.is_build())
         self.assertFalse(status.is_error())
         # Sync object
         self.mgr.set_resource_sync_synced(self.ctx, res)

--- a/aim/tests/unit/test_hashtree_db_listener.py
+++ b/aim/tests/unit/test_hashtree_db_listener.py
@@ -213,7 +213,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
 
         if not monitored:
             # Changing sync status of the EPG will bring everything back
-            epg = self.mgr.update(self.ctx, epg)
+            self.mgr.set_resource_sync_pending(self.ctx, epg)
+            epg = self.mgr.get(self.ctx, epg)
             # All the objects are in synced state
             for obj in [ap, epg2, epg]:
                 self.assertEqual(
@@ -320,10 +321,6 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         my_cfg_tree = tree.StructuredHashTree()
         my_mon_tree = tree.StructuredHashTree()
         self.db_l.tt_maker.update(my_mon_tree, [tn])
-        # Since the objects except the tenant created are in sync pending,
-        # they will be out of all trees
-        self.assertEqual(my_mon_tree, mon_tree)
-        self.assertEqual(my_cfg_tree, cfg_tree)
         # Succeed their creation
         self.mgr.set_resource_sync_synced(self.ctx, ap)
         self.mgr.set_resource_sync_synced(self.ctx, epg)
@@ -404,38 +401,3 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         self.assertTrue(len(self.tt_mgr.find(self.ctx)) > 0)
         self.tt_mgr.delete_all(self.ctx)
         self.assertEqual(0, len(self.tt_mgr.find(self.ctx)))
-
-    # REVISIT(ivar): for some reason, FK cascade is not honored by our UTs
-    # therefore the following test doesn't pass. Need to find the root cause.
-    # def test_aim_status_deleted(self):
-    #    tn_name = 'test_aim_status_deleted'
-    #    tn = aim_res.Tenant(name=tn_name, monitored=True)
-    #    ap = aim_res.ApplicationProfile(tenant_name=tn_name, name='ap',
-    #                                    monitored=True)
-    #    epg = aim_res.EndpointGroup(
-    #        tenant_name=tn_name, app_profile_name='ap', name='epg',
-    #        bd_name='some', monitored=True)
-    #    self.mgr.create(self.ctx, tn)
-    #    self.mgr.create(self.ctx, ap)
-    #    self.mgr.create(self.ctx, epg)
-
-    #    op_tree = self.tt_mgr.get(self.ctx, tn_name,
-    #                              tree=tree_manager.OPERATIONAL_TREE)
-    #    # Operational tree is currently empty
-    #    empty_tree = tree.StructuredHashTree()
-    #    self.assertEqual(empty_tree, op_tree)
-    #    # Create a fault
-    #    self.mgr.set_fault(
-    #        self.ctx, epg, aim_status.AciFault(
-    #            fault_code='152', external_identifier=epg.dn + '/fault-152'))
-    #    # Operational tree is not empty anymore
-    #    op_tree = self.tt_mgr.get(self.ctx, tn_name,
-    #                              tree=tree_manager.OPERATIONAL_TREE)
-    #    self.assertFalse(empty_tree == op_tree)
-
-    #    # Delete AIM status directly, should clear the tree
-    #    epg_status = self.mgr.get_status(self.ctx, epg)
-    #    self.mgr.delete(self.ctx, epg_status)
-    #    op_tree = self.tt_mgr.get(self.ctx, tn_name,
-    #                              tree=tree_manager.OPERATIONAL_TREE)
-    #    self.assertEqual(empty_tree, op_tree)

--- a/aim/tests/unit/test_structured_hash_tree.py
+++ b/aim/tests/unit/test_structured_hash_tree.py
@@ -291,24 +291,37 @@ class TestStructuredHashTree(base.BaseTestCase):
         node = t.add(('keyA', 'keyA')).find(('keyA', 'keyA'))
         self.assertIsNotNone(node)
         self.assertEqual({}, node.metadata)
+        self.assertEqual([], t.find_by_metadata('foo', 1))
+        self.assertEqual([('keyA', 'keyA')], t.find_no_metadata('foo'))
 
         # new node with metadata
-        t.add(('keyA', 'keyB'), _metadata={"foo": 1})
+        t.add(('keyA', 'keyB'), _metadata={"foo": 1, "bar": 1})
         node = t.find(('keyA', 'keyB'))
         self.assertIsNotNone(node)
-        self.assertEqual({'foo': 1}, node.metadata)
+        self.assertEqual({"foo": 1, "bar": 1}, node.metadata)
         self.assertEqual({}, t.root.metadata)
+        self.assertEqual([('keyA', 'keyB')], t.find_by_metadata('foo', 1))
+        self.assertEqual([('keyA', 'keyB')], t.find_by_metadata('bar', 1))
+        self.assertEqual([], t.find_by_metadata('bar', 2))
+        self.assertEqual([('keyA', 'keyA')], t.find_no_metadata('bar'))
+        self.assertEqual([('keyA', 'keyA')], t.find_no_metadata('foo'))
+        self.assertEqual([('keyA', 'keyA'), ('keyA', 'keyB')],
+                         t.find_no_metadata('keyerror'))
 
         # existing node, no metadata change
         node = t.add(('keyA', 'keyB')).find(('keyA', 'keyB'))
         self.assertIsNotNone(node)
-        self.assertEqual({'foo': 1}, node.metadata)
+        self.assertEqual({"foo": 1, "bar": 1}, node.metadata)
 
-        # existing node, metadata change
+        # existing node, partial metadata change
         t.add(('keyA', 'keyB'), _metadata={"bar": 2})
+        t.add(('keyA', 'keyB', 'keyD'), _metadata={"bar": 3})
         node = t.find(('keyA', 'keyB'))
         self.assertIsNotNone(node)
-        self.assertEqual({'bar': 2}, node.metadata)
+        self.assertEqual({'foo': 1, 'bar': 2}, node.metadata)
+        self.assertEqual([('keyA', 'keyB', 'keyD')],
+                         t.find_by_metadata('bar', 3))
+        self.assertEqual([], t.find_by_metadata('keyerror', 0))
 
         # existing node, unset metadata
         t.add(('keyA', 'keyB'), _metadata=None)


### PR DESCRIPTION
As AIM becomes a schema instead of a library, let AID manage
completely status objects and their state, so that we don't
need to rely on northbound orchestration systems to do so.

This change reaches this goal with the following:

- AIM now doesn't set any Status object for newly created/updated
  objects;
- Status default sync_state is now N/A (covers aimctl get calls);
- On hashtree differences, AID sets the SYNC_PENDING state;
- SYNC_PENDING objects are represented by a new metadata called
  "pending" in the hashtree;
- Hashtree nodes that are converged, but with the "pending"
  attribute set, are put in SYNCED state by AID;
- SYNC_ERROR continues to work as before.

NOTE: Monitor state update can now be unreliable when multiple AIDs
are running. Will be addressed by future commits