### PR TITLE
Cleanup status objects whenever the parent is deleted

### DIFF
--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -396,16 +396,18 @@ class AimManager(object):
 
     def _get_status_params(self, context, resource):
         res_type = type(resource).__name__
-        db_obj = self._query_db_obj(context.store, resource)
-        if db_obj is None:
-            # TODO(ivar): should we raise a proper exception?
-            return None, None
-        try:
-            res_id = db_obj.aim_id
-        except AttributeError:
-            LOG.warn("Resource with type %s doesn't support status" %
-                     res_type)
-            return None, None
+        res_id = getattr(resource, 'aim_id', None)
+        if not res_id:
+            db_obj = self._query_db_obj(context.store, resource)
+            if db_obj is None:
+                # TODO(ivar): should we raise a proper exception?
+                return None, None
+            try:
+                res_id = db_obj.aim_id
+            except AttributeError:
+                LOG.warn("Resource with type %s doesn't support status" %
+                         res_type)
+                return None, None
         return res_type, res_id
 
     def _iter_children(self, context, resource, **kwargs):

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -142,8 +142,8 @@ def _k8s_post_create(self, created):
 def _k8s_post_delete(self, deleted):
     if deleted:
         w = k8s_watcher_instance
-        w.klient.get_new_watch()
         event = {'type': 'DELETED', 'object': deleted}
+        w.klient.get_new_watch()
         w.klient.watch.stream = mock.Mock(return_value=[event])
         w._reset_trees = mock.Mock()
         w.q.put(event)


### PR DESCRIPTION
Fault objects will be automatically cleaned up by the operational
universe.