### PR TITLE
Reset k8s watcher retries number after a clean monitoring iteration

### DIFF
--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -396,7 +396,8 @@ class AciTenantManager(utils.AIMThread):
                     except Exception as e:
                         LOG.debug(traceback.format_exc())
                         LOG.error("An error has occurred during %s for "
-                                  "object %s" % (method, aim_object))
+                                  "object %s: %s" % (method, aim_object,
+                                                     e.message))
                         if method == base_universe.CREATE:
                             err_type = self.error_handler.analyze_exception(e)
                             # REVISIT(ivar): for now, treat UNKNOWN errors the


### PR DESCRIPTION
when observe_and_monitor_loop runs, it only exits the function when
an error occurs or the thread is stopped. This because it's blocked
in a loop internal to the one already provided by the decorator.
Because of that, whenever an error occurs its retry count is increased
by the decorator without ever having a chance to be reset. This
change makes sure that the only loop in this method is the
decorator itself.

In addition, save hashtrees from the K8S watcher every time for
operational resources, even if they look like empty update, so
that we don't lose information about the node error state.