### PR TITLE
AIM resource updates to VMM injected objects

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -551,8 +551,8 @@ resource_map = {
         'resource': resource.VmmInjectedHost,
         'exceptions': {'kernelVer': {'other': 'kernel_version'}}
     }],
-    'vmmInjectedGrp': [{
-        'resource': resource.VmmInjectedGroup,
+    'vmmInjectedContGrp': [{
+        'resource': resource.VmmInjectedContGroup,
     }],
 }
 

--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -95,7 +95,7 @@ class AimManager(object):
                      api_res.VmmInjectedReplicaSet,
                      api_res.VmmInjectedService,
                      api_res.VmmInjectedHost,
-                     api_res.VmmInjectedGroup, }
+                     api_res.VmmInjectedContGroup, }
 
     # Keep _db_model_map in AIM manager for backward compatibility
     _db_model_map = {k: None for k in aim_resources}

--- a/aim/aim_store.py
+++ b/aim/aim_store.py
@@ -227,7 +227,7 @@ class SqlAlchemyStore(AimStore):
                         models.VmmInjectedReplicaSet),
                     api_res.VmmInjectedService: models.VmmInjectedService,
                     api_res.VmmInjectedHost: models.VmmInjectedHost,
-                    api_res.VmmInjectedGroup: models.VmmInjectedGroup}
+                    api_res.VmmInjectedContGroup: models.VmmInjectedContGroup}
 
     resource_map = {}
     for k, v in db_model_map.iteritems():
@@ -325,7 +325,7 @@ class K8sStore(AimStore):
                     api_res.VmmInjectedReplicaSet: api_v1.ReplicaSet,
                     api_res.VmmInjectedService: api_v1.Service,
                     api_res.VmmInjectedHost: api_v1.Node,
-                    api_res.VmmInjectedGroup: api_v1.Pod}
+                    api_res.VmmInjectedContGroup: api_v1.Pod}
 
     def __init__(self, namespace=None, config_file=None,
                  vmm_domain=None, vmm_controller=None):

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -931,16 +931,19 @@ class VmmInjectedReplicaSet(AciResourceBase):
         ('domain_name', t.name),
         ('controller_name', t.name),
         ('namespace_name', t.name),
-        ('deployment_name', t.name),
         ('name', t.name))
     other_attributes = t.other(
-        ('display_name', t.name))
+        ('display_name', t.name),
+        ('deployment_name', t.name))
+    db_attributes = t.db(('guid', t.string()))
 
     _aci_mo_name = 'vmmInjectedReplSet'
-    _tree_parent = VmmInjectedDeployment
+    _tree_parent = VmmInjectedNamespace
 
     def __init__(self, **kwargs):
-        super(VmmInjectedReplicaSet, self).__init__({}, **kwargs)
+        super(VmmInjectedReplicaSet, self).__init__({'deployment_name': '',
+                                                     'guid': ''},
+                                                    **kwargs)
 
 
 class VmmInjectedService(AciResourceBase):
@@ -1007,8 +1010,8 @@ class VmmInjectedHost(AciResourceBase):
                                               **kwargs)
 
 
-class VmmInjectedGroup(AciResourceBase):
-    """Resource representing a VMM injected group in ACI.
+class VmmInjectedContGroup(AciResourceBase):
+    """Resource representing a VMM injected container group in ACI.
 
     Identity attributes: VMM domain type, VMM domain name, controller name,
     namespace name and group name.
@@ -1022,14 +1025,16 @@ class VmmInjectedGroup(AciResourceBase):
     other_attributes = t.other(
         ('display_name', t.name),
         ('host_name', t.name),
-        ('compute_node_name', t.name))
+        ('compute_node_name', t.name),
+        ('replica_set_name', t.name))
     db_attributes = t.db(('guid', t.string()))
 
-    _aci_mo_name = 'vmmInjectedGrp'
+    _aci_mo_name = 'vmmInjectedContGrp'
     _tree_parent = VmmInjectedNamespace
 
     def __init__(self, **kwargs):
-        super(VmmInjectedGroup, self).__init__({'host_name': '',
-                                                'compute_node_name': '',
-                                                'guid': ''},
-                                               **kwargs)
+        super(VmmInjectedContGroup, self).__init__({'host_name': '',
+                                                    'compute_node_name': '',
+                                                    'replica_set_name': '',
+                                                    'guid': ''},
+                                                   **kwargs)

--- a/aim/db/migration/alembic_migrations/versions/5d975a5c2d60_vmm_injected_objects.py
+++ b/aim/db/migration/alembic_migrations/versions/5d975a5c2d60_vmm_injected_objects.py
@@ -111,25 +111,24 @@ def upgrade():
         sa.Column('domain_name', sa.String(64), nullable=False),
         sa.Column('controller_name', sa.String(64), nullable=False),
         sa.Column('namespace_name', sa.String(64), nullable=False),
-        sa.Column('deployment_name', sa.String(64), nullable=False),
+        sa.Column('deployment_name', sa.String(64)),
         sa.Column('name', sa.String(64), nullable=False),
         sa.Column('display_name', sa.String(256), nullable=False, default=''),
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('domain_type', 'domain_name', 'controller_name',
-                            'namespace_name', 'deployment_name', 'name',
+                            'namespace_name', 'name',
                             name='uniq_aim_vmm_inj_replica_sets_identity'),
         sa.Index('idx_aim_vmm_inj_replica_sets_identity',
                  'domain_type', 'domain_name', 'controller_name',
-                 'namespace_name', 'deployment_name', 'name'),
+                 'namespace_name', 'name'),
         sa.ForeignKeyConstraint(
             ['domain_type', 'domain_name', 'controller_name',
-             'namespace_name', 'deployment_name'],
-            ['aim_vmm_inj_deployments.domain_type',
-             'aim_vmm_inj_deployments.domain_name',
-             'aim_vmm_inj_deployments.controller_name',
-             'aim_vmm_inj_deployments.namespace_name',
-             'aim_vmm_inj_deployments.name'],
-            name='fk_inj_repl_set_inj_depl'))
+             'namespace_name'],
+            ['aim_vmm_inj_namespaces.domain_type',
+             'aim_vmm_inj_namespaces.domain_name',
+             'aim_vmm_inj_namespaces.controller_name',
+             'aim_vmm_inj_namespaces.name'],
+            name='fk_inj_repl_set_inj_ns'))
 
     op.create_table(
         'aim_vmm_inj_services',
@@ -197,7 +196,7 @@ def upgrade():
             ['svc_aim_id'], ['aim_vmm_inj_services.aim_id']))
 
     op.create_table(
-        'aim_vmm_inj_groups',
+        'aim_vmm_inj_cont_groups',
         sa.Column('aim_id', sa.Integer, autoincrement=True),
         sa.Column('domain_type', sa.String(64), nullable=False),
         sa.Column('domain_name', sa.String(64), nullable=False),
@@ -206,6 +205,7 @@ def upgrade():
         sa.Column('name', sa.String(64), nullable=False),
         sa.Column('host_name', sa.String(64), nullable=False),
         sa.Column('compute_node_name', sa.String(64), nullable=False),
+        sa.Column('replica_set_name', sa.String(64), nullable=False),
         sa.Column('display_name', sa.String(256), nullable=False, default=''),
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('domain_type', 'domain_name', 'controller_name',

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -755,23 +755,22 @@ class VmmInjectedReplicaSet(model_base.Base, model_base.HasAimId,
     __table_args__ = (
         model_base.uniq_column(__tablename__, 'domain_type', 'domain_name',
                                'controller_name', 'namespace_name',
-                               'deployment_name', 'name') +
+                               'name') +
         (sa.ForeignKeyConstraint(
             ['domain_type', 'domain_name', 'controller_name',
-             'namespace_name', 'deployment_name'],
-            ['aim_vmm_inj_deployments.domain_type',
-             'aim_vmm_inj_deployments.domain_name',
-             'aim_vmm_inj_deployments.controller_name',
-             'aim_vmm_inj_deployments.namespace_name',
-             'aim_vmm_inj_deployments.name'],
-            name='fk_inj_repl_set_inj_depl'),) +
+             'namespace_name'],
+            ['aim_vmm_inj_namespaces.domain_type',
+             'aim_vmm_inj_namespaces.domain_name',
+             'aim_vmm_inj_namespaces.controller_name',
+             'aim_vmm_inj_namespaces.name'],
+            name='fk_inj_repl_set_inj_ns'),) +
         model_base.to_tuple(model_base.Base.__table_args__))
 
     domain_type = model_base.name_column(nullable=False)
     domain_name = model_base.name_column(nullable=False)
     controller_name = model_base.name_column(nullable=False)
     namespace_name = model_base.name_column(nullable=False)
-    deployment_name = model_base.name_column(nullable=False)
+    deployment_name = model_base.name_column()
 
 
 class VmmInjectedServicePort(model_base.Base):
@@ -867,11 +866,11 @@ class VmmInjectedHost(model_base.Base, model_base.HasAimId,
     os = sa.Column(sa.String(64))
 
 
-class VmmInjectedGroup(model_base.Base, model_base.HasAimId,
-                       model_base.HasName, model_base.HasDisplayName,
-                       model_base.AttributeMixin):
-    """DB model VmmInjectedGroup."""
-    __tablename__ = 'aim_vmm_inj_groups'
+class VmmInjectedContGroup(model_base.Base, model_base.HasAimId,
+                           model_base.HasName, model_base.HasDisplayName,
+                           model_base.AttributeMixin):
+    """DB model VmmInjectedContGroup."""
+    __tablename__ = 'aim_vmm_inj_cont_groups'
     __table_args__ = (
         model_base.uniq_column(__tablename__, 'domain_type', 'domain_name',
                                'controller_name', 'namespace_name') +
@@ -892,3 +891,4 @@ class VmmInjectedGroup(model_base.Base, model_base.HasAimId,
 
     host_name = model_base.name_column(nullable=False)
     compute_node_name = model_base.name_column(nullable=False)
+    replica_set_name = model_base.name_column(nullable=False)

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1390,10 +1390,11 @@ class TestAciToAimConverterVmmInjReplicaSet(TestAciToAimConverterBase,
          'exceptions': {}}]
     sample_input = [_aci_obj('vmmInjectedReplSet',
                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
-                                 'injcont/ns-[ns1]/depl-[depl1]/rs-[set1]')),
+                                 'injcont/ns-[ns1]/rs-[set1]'),
+                             deploymentName='depl1'),
                     _aci_obj('vmmInjectedReplSet',
                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
-                                 'injcont/ns-[ns2]/depl-[depl2]/rs-[set2]'),
+                                 'injcont/ns-[ns2]/rs-[set2]'),
                              nameAlias='RS')]
 
     sample_output = [
@@ -1404,7 +1405,7 @@ class TestAciToAimConverterVmmInjReplicaSet(TestAciToAimConverterBase,
         resource.VmmInjectedReplicaSet(
             domain_type='Kubernetes', domain_name='k8s',
             controller_name='cluster1', namespace_name='ns2',
-            deployment_name='depl2', name='set2', display_name='RS')
+            name='set2', display_name='RS')
     ]
 
 
@@ -1493,31 +1494,33 @@ class TestAciToAimConverterVmmInjHost(TestAciToAimConverterBase,
     ]
 
 
-class TestAciToAimConverterVmmInjGroup(TestAciToAimConverterBase,
-                                       base.TestAimDBBase):
-    resource_type = resource.VmmInjectedGroup
+class TestAciToAimConverterVmmInjContGroup(TestAciToAimConverterBase,
+                                           base.TestAimDBBase):
+    resource_type = resource.VmmInjectedContGroup
     reverse_map_output = [
-        {'resource': 'vmmInjectedGrp',
+        {'resource': 'vmmInjectedContGrp',
          'exceptions': {}}]
-    sample_input = [_aci_obj('vmmInjectedGrp',
+    sample_input = [_aci_obj('vmmInjectedContGrp',
                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
                                  'injcont/ns-[ns1]/grp-[pod1]'),
                              hostName='my.local.host',
-                             computeNodeName='host1'),
-                    _aci_obj('vmmInjectedGrp',
+                             computeNodeName='host1',
+                             replicaSetName='rs1'),
+                    _aci_obj('vmmInjectedContGrp',
                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
                                  'injcont/ns-[ns2]/grp-[pod2]'),
                              nameAlias='POD')]
 
     sample_output = [
-        resource.VmmInjectedGroup(
+        resource.VmmInjectedContGroup(
             domain_type='Kubernetes', domain_name='k8s',
             controller_name='cluster1', compute_node_name='host1',
-            name='pod1', namespace_name='ns1', host_name='my.local.host'),
-        resource.VmmInjectedGroup(
+            name='pod1', namespace_name='ns1', host_name='my.local.host',
+            replica_set_name='rs1'),
+        resource.VmmInjectedContGroup(
             domain_type='Kubernetes', domain_name='k8s',
             controller_name='cluster1', namespace_name='ns2',
-            name='pod2', display_name='POD')
+            name='pod2', display_name='POD', replica_set_name='')
     ]
 
 
@@ -2951,8 +2954,7 @@ class TestAimToAciConverterVmmInjDeployment(TestAimToAciConverterBase,
 def get_example_aim_vmm_inj_replica_set(**kwargs):
     example = resource.VmmInjectedReplicaSet(
         domain_type='Kubernetes', domain_name='k8s',
-        controller_name='cluster1', namespace_name='ns1',
-        deployment_name='depl1', name='set1')
+        controller_name='cluster1', namespace_name='ns1', name='set1')
     example.__dict__.update(kwargs)
     return example
 
@@ -2960,18 +2962,24 @@ def get_example_aim_vmm_inj_replica_set(**kwargs):
 class TestAimToAciConverterVmmInjReplicaSet(TestAimToAciConverterBase,
                                             base.TestAimDBBase):
     sample_input = [
-        get_example_aim_vmm_inj_replica_set(display_name='RS1'),
+        get_example_aim_vmm_inj_replica_set(display_name='RS1',
+                                            deployment_name='depl1',
+                                            guid='123'),
         get_example_aim_vmm_inj_replica_set(name='set2')]
 
     sample_output = [
         [_aci_obj('vmmInjectedReplSet',
                   dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
-                      'injcont/ns-[ns1]/depl-[depl1]/rs-[set1]'),
-                  nameAlias='RS1')],
+                      'injcont/ns-[ns1]/rs-[set1]'),
+                  nameAlias='RS1',
+                  deploymentName='depl1',
+                  guid='123')],
         [_aci_obj('vmmInjectedReplSet',
                   dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
-                      'injcont/ns-[ns1]/depl-[depl1]/rs-[set2]'),
-                  nameAlias='')]
+                      'injcont/ns-[ns1]/rs-[set2]'),
+                  nameAlias='',
+                  deploymentName='',
+                  guid='')]
     ]
 
 
@@ -3069,36 +3077,39 @@ class TestAimToAciConverterVmmInjHost(TestAimToAciConverterBase,
     ]
 
 
-def get_example_aim_vmm_inj_group(**kwargs):
-    example = resource.VmmInjectedGroup(
+def get_example_aim_vmm_inj_cont_group(**kwargs):
+    example = resource.VmmInjectedContGroup(
         domain_type='Kubernetes', domain_name='k8s',
         controller_name='cluster1', namespace_name='ns1', name='pod1')
     example.__dict__.update(kwargs)
     return example
 
 
-class TestAimToAciConverterVmmInjGroup(TestAimToAciConverterBase,
-                                       base.TestAimDBBase):
+class TestAimToAciConverterVmmInjContGroup(TestAimToAciConverterBase,
+                                           base.TestAimDBBase):
     sample_input = [
-        get_example_aim_vmm_inj_group(display_name='POD1',
-                                      host_name='my.local.host',
-                                      compute_node_name='host1',
-                                      guid='123'),
-        get_example_aim_vmm_inj_group(name='pod2')]
+        get_example_aim_vmm_inj_cont_group(display_name='POD1',
+                                           host_name='my.local.host',
+                                           compute_node_name='host1',
+                                           guid='123',
+                                           replica_set_name='rs1'),
+        get_example_aim_vmm_inj_cont_group(name='pod2')]
 
     sample_output = [
-        [_aci_obj('vmmInjectedGrp',
+        [_aci_obj('vmmInjectedContGrp',
                   dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
                       'injcont/ns-[ns1]/grp-[pod1]'),
                   hostName='my.local.host',
                   computeNodeName='host1',
                   guid='123',
-                  nameAlias='POD1')],
-        [_aci_obj('vmmInjectedGrp',
+                  nameAlias='POD1',
+                  replicaSetName='rs1')],
+        [_aci_obj('vmmInjectedContGrp',
                   dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
                       'injcont/ns-[ns1]/grp-[pod2]'),
                   hostName='',
                   computeNodeName='',
                   guid='',
-                  nameAlias='')]
+                  nameAlias='',
+                  replicaSetName='')]
     ]


### PR DESCRIPTION
* Move replica-set under namespace, make deployment
  name a regular attribute and add guid
* Rename VmmInjectedGroup to VmmInjectedContGroup
  for consistency with ACI name. Add reference to
  ReplicaSet.

Signed-off-by: Amit Bose <amitbose@gmail.com>