### PR TITLE
Include endpoints in injected Service objects

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -225,6 +225,10 @@ vmmInjectedSvcPort_converter = utils.list_dict(
                    'converter': port,
                    'default': '0'}, },
     ['port', 'protocol', 'target_port'])
+vmmInjectedSvcEp_converter = utils.list_dict(
+    'endpoints',
+    {'pod_name': {'other': 'contGrpName'}},
+    ['pod_name'])
 infraRsVlanNs_vmm_converter = utils.dn_decomposer(['vlan_pool_name',
                                                    'vlan_pool_type'],
                                                   'fvnsVlanInstP')
@@ -539,13 +543,17 @@ resource_map = {
     }],
     'vmmInjectedSvc': [{
         'resource': resource.VmmInjectedService,
-        'skip': ['service_ports'],
+        'skip': ['service_ports', 'endpoints'],
         'exceptions': {'type': {'other': 'service_type'},
                        'lbIp': {'other': 'load_balancer_ip'}},
     }],
     'vmmInjectedSvcPort': [{
         'resource': resource.VmmInjectedService,
         'converter': vmmInjectedSvcPort_converter,
+    }],
+    'vmmInjectedSvcEp': [{
+        'resource': resource.VmmInjectedService,
+        'converter': vmmInjectedSvcEp_converter,
     }],
     'vmmInjectedHost': [{
         'resource': resource.VmmInjectedHost,

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -967,7 +967,9 @@ class VmmInjectedService(AciResourceBase):
         ('service_ports', t.list_of_dicts(('port', t.ports),
                                           ('protocol', t.string(32)),
                                           ('target_port', t.string(32)),
-                                          ('node_port', t.ports))))
+                                          ('node_port', t.ports))),
+        ('endpoints', t.list_of_dicts(('ip', t.string()),
+                                      ('pod_name', t.name))))
     db_attributes = t.db(('guid', t.string()))
 
     _aci_mo_name = 'vmmInjectedSvc'
@@ -979,6 +981,7 @@ class VmmInjectedService(AciResourceBase):
              'cluster_ip': '0.0.0.0',
              'load_balancer_ip': '0.0.0.0',
              'service_ports': [],
+             'endpoints': [],
              'guid': ''},
             **kwargs)
 

--- a/aim/db/migration/alembic_migrations/versions/5d975a5c2d60_vmm_injected_objects.py
+++ b/aim/db/migration/alembic_migrations/versions/5d975a5c2d60_vmm_injected_objects.py
@@ -196,6 +196,15 @@ def upgrade():
             ['svc_aim_id'], ['aim_vmm_inj_services.aim_id']))
 
     op.create_table(
+        'aim_vmm_inj_service_endpoints',
+        sa.Column('svc_aim_id', sa.Integer, nullable=False),
+        sa.Column('ip', sa.String(64)),
+        sa.Column('pod_name', sa.String(64)),
+        sa.PrimaryKeyConstraint('svc_aim_id', 'ip', 'pod_name'),
+        sa.ForeignKeyConstraint(
+            ['svc_aim_id'], ['aim_vmm_inj_services.aim_id']))
+
+    op.create_table(
         'aim_vmm_inj_cont_groups',
         sa.Column('aim_id', sa.Integer, autoincrement=True),
         sa.Column('domain_type', sa.String(64), nullable=False),

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1414,11 +1414,14 @@ class TestAciToAimConverterVmmInjService(TestAciToAimConverterBase,
     resource_type = resource.VmmInjectedService
     reverse_map_output = [
         {'resource': 'vmmInjectedSvc',
-         'skip': ['servicePorts'],
+         'skip': ['servicePorts', 'endpoints'],
          'exceptions': {'service_type': {'other': 'type'},
                         'load_balancer_ip': {'other': 'lbIp'}}},
         {'resource': 'vmmInjectedSvcPort',
          'converter': converter.vmmInjectedSvcPort_converter,
+         'exceptions': {}},
+        {'resource': 'vmmInjectedSvcEp',
+         'converter': converter.vmmInjectedSvcEp_converter,
          'exceptions': {}}]
     sample_input = [[_aci_obj('vmmInjectedSvc',
                               dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
@@ -1440,7 +1443,15 @@ class TestAciToAimConverterVmmInjService(TestAciToAimConverterBase,
                               port='56',
                               protocol='udp',
                               targetPort='2056',
-                              nodePort='http')],
+                              nodePort='http'),
+                     _aci_obj('vmmInjectedSvcEp',
+                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                                  'injcont/ns-[ns1]/svc-[svc1]/ep-foo'),
+                              contGrpName='foo'),
+                     _aci_obj('vmmInjectedSvcEp',
+                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                                  'injcont/ns-[ns1]/svc-[svc1]/ep-bar'),
+                              contGrpName='bar')],
                     _aci_obj('vmmInjectedSvc',
                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
                                  'injcont/ns-[ns2]/svc-[svc2]'),
@@ -1455,7 +1466,9 @@ class TestAciToAimConverterVmmInjService(TestAciToAimConverterBase,
             service_ports=[{'port': 'https', 'protocol': 'tcp',
                             'target_port': 'INT_HTTP'},
                            {'port': '56', 'protocol': 'udp',
-                            'target_port': '2056', 'node_port': 'http'}]),
+                            'target_port': '2056', 'node_port': 'http'}],
+            endpoints=[{'pod_name': 'foo'},
+                       {'pod_name': 'bar'}]),
         resource.VmmInjectedService(
             domain_type='Kubernetes', domain_name='k8s',
             controller_name='cluster1', namespace_name='ns2', name='svc2',
@@ -3004,7 +3017,9 @@ class TestAimToAciConverterVmmInjService(TestAimToAciConverterBase,
                            {'port': '56',
                             'protocol': 'udp',
                             'target_port': '2056',
-                            'node_port': '80'}]),
+                            'node_port': '80'}],
+            endpoints=[{'ip': '1.2.3.4', 'pod_name': 'foo'},
+                       {'ip': '1.2.3.5', 'pod_name': 'bar'}]),
     ]
 
     sample_output = [
@@ -3039,7 +3054,15 @@ class TestAimToAciConverterVmmInjService(TestAimToAciConverterBase,
                   port='56',
                   protocol='udp',
                   targetPort='2056',
-                  nodePort='http')]
+                  nodePort='http'),
+         _aci_obj('vmmInjectedSvcEp',
+                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                      'injcont/ns-[ns1]/svc-[svc1]/ep-foo'),
+                  contGrpName='foo'),
+         _aci_obj('vmmInjectedSvcEp',
+                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                      'injcont/ns-[ns1]/svc-[svc1]/ep-bar'),
+                  contGrpName='bar')]
     ]
 
 

--- a/aim/tree_manager.py
+++ b/aim/tree_manager.py
@@ -286,7 +286,8 @@ class AimHashTreeMaker(object):
     @staticmethod
     def _extract_dn(res):
         try:
-            return res.dn
+            if not isinstance(res, aim_status.AciStatus):
+                return res.dn
         except Exception as e:
             LOG.warning("Failed to extract DN for resource %s: %s",
                         res, e)


### PR DESCRIPTION
Most of the change is mechanical except for
handling of service endpoints with Kubernetes
store since Kubernetes saves endpoints in a
different object ("Endpoints") instead of the
"Service" object. Currently we support
read-only access to service endpoints with
Kubernetes store. Also kubernetes watcher is
modified to listen for Endpoints events and
modify them into Service events.

Signed-off-by: Amit Bose <amitbose@gmail.com>