### PR TITLE
Fixes to filtering of certains Pods in Kubernetes watcher

### DIFF
--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -258,7 +258,8 @@ class AimManager(object):
                 context.store.make_resource(resource_class, obj))
         return result
 
-    def get_status(self, context, resource, for_update=False):
+    def get_status(self, context, resource, for_update=False,
+                   create_if_absent=True):
         """Get status of an AIM resource, if any.
 
         Values of identity attributes of parameter 'resource' are used
@@ -274,6 +275,8 @@ class AimManager(object):
                         resource_type=res_type, resource_id=res_id,
                         resource_root=resource.root), for_update=for_update)
                     if not status:
+                        if not create_if_absent:
+                            return
                         # Create one with default values
                         # NOTE(ivar): Sometimes we need the status of an object
                         # even if AID wasn't able to calculate it yet

--- a/aim/tools/cli/commands/manager.py
+++ b/aim/tools/cli/commands/manager.py
@@ -184,7 +184,7 @@ def get(klass):
         res = klass(**kwargs)
         res = manager.get(aim_ctx, res)
         if res:
-            stat = manager.get_status(aim_ctx, res)
+            stat = manager.get_status(aim_ctx, res, create_if_absent=False)
             print_resource(res, plain=plain)
             if stat:
                 print_resource(stat, plain=plain)


### PR DESCRIPTION
Processing AciStatus events for Pods that are meant to
be hidden messes up the config hash-tree by inserting
unwanted nodes. To avoid this two fixes are added:

Fix 1: Avoid creating unwanted AciStatus object in
get_status() for DELETED events.
Fix 2: All AciStatus events for a hidden Pod are
treated as DELETED events.

Signed-off-by: Amit Bose <amitbose@gmail.com>