### PR TITLE
Move AID to traditional python threading

### DIFF
--- a/aim/agent/aid/event_services/rpc.py
+++ b/aim/agent/aid/event_services/rpc.py
@@ -103,7 +103,7 @@ class Connection(object):
         target = oslo_messaging.Target(
             topic=topic, server=aim_cfg.CONF.aim.aim_service_identifier)
         server = oslo_messaging.get_rpc_server(self.transport, target,
-                                               endpoints, executor='eventlet')
+                                               endpoints)
         self.servers.append(server)
 
     def consume_in_threads(self):

--- a/aim/agent/aid/event_services/rpc_service.py
+++ b/aim/agent/aid/event_services/rpc_service.py
@@ -13,8 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import eventlet
-eventlet.monkey_patch()
+import time
 
 from oslo_log import log as logging
 
@@ -38,7 +37,7 @@ class RpcEventService(event_service_base.EventServiceBase):
         LOG.info("RPC Event Service initialized!")
         try:
             while self.run_daemon_loop:
-                eventlet.sleep(1)
+                time.sleep(1)
         finally:
             LOG.info("Closing RPC connection.")
             self.conn.close()

--- a/aim/agent/aid/service.py
+++ b/aim/agent/aid/service.py
@@ -24,6 +24,7 @@ import semantic_version
 from aim.agent.aid import event_handler
 from aim.agent.aid.universes.aci import aci_universe
 from aim.agent.aid.universes import aim_universe
+from aim.agent.aid.universes import constants as lcon
 from aim.agent.aid.universes.k8s import k8s_watcher
 from aim import aim_manager
 from aim.api import resource
@@ -59,6 +60,12 @@ class AID(object):
         # DB session which can result in conflicts.
         # TODO(amitbose) Fix ConfigManager to not use cached AimContext
         self.conf_manager = aim_cfg.ConfigManager(aim_ctx, self.host)
+        self.k8s_watcher = None
+        self.single_aid = False
+        if conf.aim.aim_store == 'k8s':
+            self.single_aid = True
+            self.k8s_watcher = k8s_watcher.K8sWatcher()
+            self.k8s_watcher.run()
 
         # Define multiverse pairs, First position is desired state
         self.multiverse = [
@@ -106,12 +113,6 @@ class AID(object):
         self.events = event_handler.EventHandler().initialize(
             self.conf_manager)
         self.max_down_time = 4 * self.report_interval
-        self.k8s_watcher = None
-        self.single_aid = False
-        if conf.aim.aim_store == 'k8s':
-            self.single_aid = True
-            self.k8s_watcher = k8s_watcher.K8sWatcher()
-            self.k8s_watcher.run()
 
     def daemon_loop(self):
         aim_ctx = context.AimContext(store=api.get_store())
@@ -169,9 +170,10 @@ class AID(object):
         # time for events to happen
 
         # Observe the two universes to fix their current state
-        for pair in self.multiverse:
-            pair[DESIRED].observe()
-            pair[CURRENT].observe()
+        with utils.get_rlock(lcon.AID_OBSERVER_LOCK):
+            for pair in self.multiverse:
+                pair[DESIRED].observe()
+                pair[CURRENT].observe()
 
         # Reconcile everything
         changes = False

--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -15,11 +15,11 @@
 
 import collections
 import json
+import time
 import traceback
 
 from acitoolkit import acitoolkit
 from apicapi import apic_client
-import eventlet
 from oslo_log import log as logging
 
 from aim.agent.aid.universes.aci import converter
@@ -69,10 +69,11 @@ class WebSocketContext(object):
         self._spawn_monitors()
 
     def _spawn_monitors(self):
-        eventlet.spawn(self._thread_monitor, self.session.login_thread,
-                       'login_thread')
-        eventlet.spawn(self._thread_monitor, self.session.subscription_thread,
-                       'subscription_thread')
+        utils.spawn_thread(self._thread_monitor, self.session.login_thread,
+                           'login_thread')
+        utils.spawn_thread(
+            self._thread_monitor, self.session.subscription_thread,
+            'subscription_thread')
 
     def _reload_websocket_config(self):
         # Don't subscribe in this case
@@ -208,7 +209,7 @@ class WebSocketContext(object):
                 else:
                     LOG.debug("Thread %s is in good shape" % name)
                     retries = None
-                eventlet.sleep(self.monitor_sleep_time)
+                time.sleep(self.monitor_sleep_time)
                 # for testing purposes
                 self.monitor_runs -= 1
         except Exception as e:

--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -212,6 +212,8 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
                                           aim_resource.AciRoot) and monitored:
                                 # Monitored Universe doesn't delete Tenant
                                 # Resources
+                                LOG.info('%s skipping delete for object %s' %
+                                         (self.name, resource))
                                 continue
                             if monitored:
                                 # Only delete a resource if monitored

--- a/aim/agent/aid/universes/constants.py
+++ b/aim/agent/aid/universes/constants.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2017 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+# Keep all the lock names/prefixes here stored in constants for an easier
+# lookup of who is using them.
+
+# Access to the k8s watcher tree shared resource
+K8S_WATCHER_TREE_LOCK = 'k8s_watcher_trees'
+# Prevent AID from observing new state for all roots
+AID_OBSERVER_LOCK = 'aid_observer_lock'
+# Access ACI tree of a specific root
+ACI_TREE_LOCK_NAME_PREFIX = "root_aci_tree_lock-"

--- a/aim/agent/aid/universes/k8s/k8s_watcher.py
+++ b/aim/agent/aid/universes/k8s/k8s_watcher.py
@@ -20,6 +20,7 @@ import traceback
 from oslo_log import log as logging
 
 from aim.agent.aid import event_handler
+from aim.agent.aid.universes import constants as lcon
 from aim import aim_manager
 from aim.api import resource
 from aim.api import status
@@ -43,7 +44,6 @@ BUILDER_LOOP_MAX_RETRIES = 5
 MONITOR_LOOP_MAX_WAIT = 5
 MONITOR_LOOP_MAX_RETRIES = 5
 
-COLD_BUILD_TIME = 10
 WARM_BUILD_TIME = 0.2
 
 ACTION_CREATED = 'added'
@@ -75,7 +75,6 @@ class K8sWatcher(object):
         self.klient = self.ctx.store.klient
         self.namespace = self.ctx.store.namespace
         self.trees = {}
-        self.warmup_time = COLD_BUILD_TIME
         self.q = queue.Queue()
         self.event_handler = event_handler.EventHandler
         self._stop = False
@@ -87,6 +86,7 @@ class K8sWatcher(object):
         self._k8s_types_to_observe = set([])
         self._k8s_aim_type_map = {}
         self._k8s_kinds = set([])
+        self._needs_init = True
 
         for aim_res in aim_manager.AimManager.aim_resources:
             if issubclass(aim_res, resource.AciResourceBase):
@@ -182,18 +182,50 @@ class K8sWatcher(object):
             if self.klient.watch:
                 self.klient.stop_watch()
             self._observe_thread_state = {}
+            self._needs_init = True
             raise exc
         time.sleep(MONITOR_LOOP_MAX_WAIT)
 
-    def _start_observers(self, types_to_observe):
-        self._reset_trees()
-        self._renew_klient_watch()
+    def _init_aim_k8s(self, types_to_observe):
+        if self._needs_init:
+            # NOTE(ivar): we need to lock the observer here to prevent it
+            # from reading empty or incomplete trees
+            # REVISIT(ivar): this is NOT gonna work for multi AID. In general,
+            # the whole K8S watcher cannot run as-is in a multi AID environment
+            with utils.get_rlock(lcon.AID_OBSERVER_LOCK):
+                self._reset_trees()
+                self._renew_klient_watch()
 
-        self._observe_thread_state = {}
+                self._version_by_type = {}
+                for typ in self._k8s_types_to_observe:
+                    self._init_stream_for_type(typ)
+                self._persistence_loop(save_on_empty=True)
+                LOG.info("Trees initialized")
+                self._needs_init = False
+
+    @utils.rlock(lcon.K8S_WATCHER_TREE_LOCK)
+    def _start_observers(self, types_to_observe):
+        self._init_aim_k8s(types_to_observe)
         for id, typ in enumerate(list(types_to_observe)):
             self._observe_thread_state[id] = dict(watch_stop=False)
-            thd = utils.spawn_thread(self._observe_objects, typ, id)
+            thd = utils.spawn_thread(
+                self._observe_objects, self.klient.watch.stream, typ, id,
+                self._version_by_type.get(typ))
             self._observe_thread_state[id]['thread'] = thd
+
+    def _init_stream_for_type(self, k8s_type):
+
+        def wrapped_list(f, k8s_type, *args, **kwargs):
+            result = []
+            list = self.klient.list(k8s_type, namespace=kwargs['namespace'])
+            self._version_by_type[k8s_type] = list[
+                'metadata']['resourceVersion']
+            for item in list['items']:
+                result.append({'type': ACTION_CREATED,
+                               'raw_object': item,
+                               'object': item})
+            return result
+        self._observe_objects(wrapped_list, k8s_type, None, None)
 
     def _check_observers(self):
         exc = None
@@ -222,19 +254,19 @@ class K8sWatcher(object):
             tstate['http_resp'] = resp
         return resp
 
-    def _observe_objects(self, k8s_type, id):
+    def _observe_objects(self, func, k8s_type, id, resource_version=None):
         my_state = self._observe_thread_state.get(id, {})
         LOG.info('Start observing %s objects', k8s_type.kind)
         ev_filt = self._event_filters.get(k8s_type, lambda x: True)
-        if not my_state['watch_stop']:
+        if not my_state.get('watch_stop', False):
             try:
                 ns = (self.namespace
                       if k8s_type == api_v1.AciContainersObject else None)
-                for event in self.klient.watch.stream(
-                        self.wrap_list_call, k8s_type,
-                        _thread_state=my_state,
-                        namespace=ns):
-                    if my_state['watch_stop']:
+                kwargs = {'_thread_state': my_state, 'namespace': ns}
+                if resource_version is not None:
+                    kwargs['resource_version'] = resource_version
+                for event in func(self.wrap_list_call, k8s_type, **kwargs):
+                    if my_state.get('watch_stop', False):
                         LOG.debug('Stopping %s objects thread', k8s_type.kind)
                         break
                     ev_name = event.get('object',
@@ -263,7 +295,6 @@ class K8sWatcher(object):
         except queue.Empty:
             pass
         self.tt_mgr.delete_all(self.ctx)
-        self.warmup_time = COLD_BUILD_TIME
         self.trees = {}
 
     @utils.retry_loop(BUILDER_LOOP_MAX_WAIT, BUILDER_LOOP_MAX_RETRIES,
@@ -271,29 +302,33 @@ class K8sWatcher(object):
     def persistence_loop(self):
         self._persistence_loop()
 
-    def _persistence_loop(self):
+    @utils.rlock(lcon.K8S_WATCHER_TREE_LOCK)
+    def _persistence_loop(self, save_on_empty=False,
+                          warmup_wait=WARM_BUILD_TIME):
         if self._stop:
             LOG.info("Quitting k8s builder loop")
             raise utils.ThreadExit()
         first_event_time = None
-        warmup_wait = COLD_BUILD_TIME
         affected_tenants = set(self.affected_tenants)
-        while warmup_wait > 0:
+        squash_time = warmup_wait if not save_on_empty else float('inf')
+        while squash_time > 0:
             event = self._get_event(warmup_wait)
             if not first_event_time:
                 first_event_time = time.time()
-            warmup_wait = (first_event_time + self.warmup_time -
-                           time.time())
+            if not save_on_empty:
+                squash_time = (first_event_time + warmup_wait -
+                               time.time())
             if event:
                 LOG.debug('Got save event from queue')
                 affected_tenants |= self._process_event(event)
+            elif save_on_empty:
+                break
 
         if affected_tenants:
             LOG.info('Saving trees for tenants: %s', affected_tenants)
             try:
                 # Save procedure can be context switched at this point
                 self._save_trees(affected_tenants)
-                self.warmup_time = WARM_BUILD_TIME
                 self.affected_tenants = set()
             except Exception:
                 LOG.error(traceback.format_exc())
@@ -423,7 +458,7 @@ class K8sWatcher(object):
                     parsed_event['event_type'] = ACTION_DELETED.upper()
                     return
 
-    def _save_trees(self, affected_tenants):
+    def _get_trees_to_save(self, affected_tenants):
         cfg_trees = []
         oper_trees = []
         mon_trees = []
@@ -437,6 +472,11 @@ class K8sWatcher(object):
             tree = self.trees.get(self.tt_builder.OPER).get(tenant)
             if tree and tree.root_key:
                 oper_trees.append(tree)
+        return cfg_trees, oper_trees, mon_trees
+
+    def _save_trees(self, affected_tenants):
+        cfg_trees, oper_trees, mon_trees = self._get_trees_to_save(
+            affected_tenants)
 
         if cfg_trees:
             self.tt_mgr.update_bulk(self.ctx, cfg_trees)

--- a/aim/config.py
+++ b/aim/config.py
@@ -19,7 +19,6 @@ import time
 import traceback
 
 from apicapi import config as apic_config  # noqa
-import greenlet
 from oslo_config import cfg
 from oslo_log import log as logging
 
@@ -441,18 +440,10 @@ class ConfigSubscriber(utils.AIMThread):
 
     def run(self):
         LOG.info("Starting main loop for config subscriber")
-        try:
-            while True:
-                self._main_loop()
-        except greenlet.GreenletExit:
-            try:
-                # Unsubscribe all the config callbacks
-                self.config_mgr.callback_unsubscribe(
-                    self._change_polling_interval)
-            finally:
-                # We need to make sure that this thread dies upon
-                # GreenletExit
-                return
+        while not self._stop:
+            self._main_loop()
+        # Unsubscribe all the config callbacks
+        self.config_mgr.callback_unsubscribe(self._change_polling_interval)
 
     def _main_loop(self):
         try:
@@ -460,9 +451,6 @@ class ConfigSubscriber(utils.AIMThread):
             self._poll_and_execute()
             utils.wait_for_next_cycle(start, self.polling_interval, LOG,
                                       readable_caller='Config Subscriber')
-        except greenlet.GreenletExit:
-            # Raise GreenletExit to make sure that the thread dies
-            raise
         except Exception as e:
             LOG.error("An exception has occurred in config subscriber thread "
                       "%s" % e.message)

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -130,8 +130,7 @@ def _k8s_post_create(self, created):
         w.klient.watch.stream = mock.Mock(return_value=[event])
         w._reset_trees = mock.Mock()
         w.q.put(event)
-        w.warmup_time = -1
-        w._persistence_loop()
+        w._persistence_loop(save_on_empty=True, warmup_wait=0)
 
 
 def _k8s_post_delete(self, deleted):
@@ -142,8 +141,7 @@ def _k8s_post_delete(self, deleted):
         w.klient.watch.stream = mock.Mock(return_value=[event])
         w._reset_trees = mock.Mock()
         w.q.put(event)
-        w.warmup_time = -1
-        w._persistence_loop()
+        w._persistence_loop(save_on_empty=True, warmup_wait=0)
 
 
 class TestAimDBBase(BaseTestCase):

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -13,11 +13,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import eventlet
-# https://github.com/eventlet/eventlet/issues/401
-eventlet.sleep()
-eventlet.monkey_patch()
-
 import logging  # noqa
 import os
 

--- a/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
@@ -17,7 +17,6 @@ import collections
 import copy
 
 from apicapi import apic_client
-import greenlet
 import json
 import mock
 
@@ -430,16 +429,6 @@ class TestAciTenant(base.TestAimDBBase, TestAciClientMixin):
         manager.ws_context.has_event = mock.Mock(side_effect=KeyError)
         # Main loop is not raising
         manager._main_loop()
-        # Failure by GreenletExit
-        manager.ws_context.has_event = mock.Mock(
-            side_effect=greenlet.GreenletExit)
-        self.assertRaises(greenlet.GreenletExit, manager._main_loop)
-        # Upon GreenletExit, even run stops the loop
-        manager.run()
-        # Instance unsubscribe could rise an exception itself
-        with mock.patch('acitoolkit.acitoolkit.Session.unsubscribe',
-                        side_effect=Exception):
-            manager.run()
 
     def test_squash_events(self):
         double_events = [

--- a/aim/tests/unit/agent/aid_universes/test_k8s_watcher.py
+++ b/aim/tests/unit/agent/aid_universes/test_k8s_watcher.py
@@ -13,12 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-
-import eventlet
-# https://github.com/eventlet/eventlet/issues/401
-eventlet.sleep()
-eventlet.monkey_patch()
-
 import copy
 import mock
 from mock import patch

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -339,8 +339,6 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # reconcile the state
         agent._daemon_loop(self.ctx)
 
-        for tenant in agent.current_universe.serving_tenants.values():
-            tenant._subscribe_tenant()
         # The ACI universe will not push the configuration unless explicitly
         # called
         self.assertFalse(

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -89,12 +89,17 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
             'aim.agent.aid.universes.k8s.k8s_watcher.K8sWatcher.stop_threads')
         self.stop_watcher_threads.start()
 
+        self.hb_loop = mock.patch(
+            'aim.agent.aid.service.AID._spawn_heartbeat_loop')
+        self.hb_loop.start()
+
         self.addCleanup(self.tenant_thread.stop)
         self.addCleanup(self.thread_dead.stop)
         self.addCleanup(self.thread_warm.stop)
         self.addCleanup(self.events_thread.stop)
         self.addCleanup(self.watcher_threads.stop)
         self.addCleanup(self.stop_watcher_threads.stop)
+        self.addCleanup(self.hb_loop.stop)
 
     def _reset_apic_client(self):
         apic_client.ApicSession.post_body_dict = self.old_post

--- a/aim/tests/unit/test_utils.py
+++ b/aim/tests/unit/test_utils.py
@@ -90,3 +90,16 @@ class TestUtils(base.TestAimDBBase):
             [('fvTenant', 'common'), ('vzBrCP', 'p'), ('vzSubj', 'p'),
              ('vzInTerm', 'intmnl'), ('vzRsFiltAtt', 'p')],
             internal_utils.decompose_dn(type, dn))
+
+    @internal_utils.rlock('test')
+    def locked_func(self):
+        with internal_utils.get_rlock('test2'):
+            pass
+
+    def test_cover_lock(self):
+        internal_utils.all_locks = {}
+        self.assertTrue('test' not in internal_utils.all_locks)
+        self.locked_func()
+        self.assertTrue('test' in internal_utils.all_locks)
+        self.assertTrue('test2' in internal_utils.all_locks)
+        self.assertEqual(2, len(internal_utils.all_locks))

--- a/aim/tools/cli/service.py
+++ b/aim/tools/cli/service.py
@@ -13,11 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import eventlet
-# https://github.com/eventlet/eventlet/issues/401
-eventlet.sleep()
-eventlet.monkey_patch()
-
 from aim.agent.aid.event_services import polling
 from aim.agent.aid.event_services import rpc_service
 from aim.agent.aid import service

--- a/aim/tree_manager.py
+++ b/aim/tree_manager.py
@@ -492,7 +492,7 @@ class HashTreeBuilder(object):
                                              oper: ([], [])})
                             updates_by_root[
                                 parent_key][oper][tree_index].append(parent)
-                    else:
+                    elif tree_index == 0:
                         # Parent doesn't exist for some reason, delete the
                         # status object
                         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ alembic
 -e git+https://github.com/noironetworks/acitoolkit.git@noiro-lite#egg=acitoolkit
 -e git+https://github.com/noironetworks/apicapi.git@master#egg=apicapi
 Click
-eventlet!=0.18.3,>=0.18.2 # MIT
 jsonschema  # MIT
 kubernetes
 oslo.concurrency


### PR DESCRIPTION
As we become more dependent on multi-threading, Greenthread patch-and-pray libraries start behaving unpredictably, especially when running in containers (probably having something to do with the libc version). The most common problem we see is threads hanging indefinitely, bringing AID to an unrecoverable state unless restarted.
With this patch, we move AID to traditional python threading and introduce all the necessary concurrency management (eg. locking).