### PR TITLE
Adapt to injected object changes on APIC

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -527,10 +527,6 @@ resource_map = {
     'vmmCtrlrP': [{
         'resource': resource.VMMController,
     }],
-    'vmmInjectedCont': [{
-        'resource': resource.VMMController,
-        'to_resource': utils.no_op_to_resource,
-    }],
     'vmmInjectedNs': [{
         'resource': resource.VmmInjectedNamespace,
     }],

--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -689,5 +689,8 @@ class AciTenantManager(utils.AIMThread):
 
     @staticmethod
     def is_child_object(type):
-        return type not in [x['resource']._aci_mo_name for x in
-                            converter.resource_map.get(type, [])]
+        if type == 'tagInst':
+            return True
+        aim_res = converter.resource_map.get(type, [])
+        return aim_res and type not in [x['resource']._aci_mo_name
+                                        for x in aim_res]

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -888,7 +888,7 @@ class VmmInjectedNamespace(AciResourceBase):
         ('display_name', t.name))
 
     _aci_mo_name = 'vmmInjectedNs'
-    _tree_parent = VMMController
+    _tree_parent = None
 
     def __init__(self, **kwargs):
         super(VmmInjectedNamespace, self).__init__({}, **kwargs)
@@ -1004,7 +1004,7 @@ class VmmInjectedHost(AciResourceBase):
         ('os', t.string()))
 
     _aci_mo_name = 'vmmInjectedHost'
-    _tree_parent = VMMController
+    _tree_parent = None
 
     def __init__(self, **kwargs):
         super(VmmInjectedHost, self).__init__({'host_name': '',

--- a/aim/db/migration/alembic_migrations/versions/5d975a5c2d60_vmm_injected_objects.py
+++ b/aim/db/migration/alembic_migrations/versions/5d975a5c2d60_vmm_injected_objects.py
@@ -70,13 +70,7 @@ def upgrade():
                             'name',
                             name='uniq_aim_vmm_inj_namespaces_identity'),
         sa.Index('idx_aim_vmm_inj_namespaces_identity',
-                 'domain_type', 'domain_name', 'controller_name', 'name'),
-        sa.ForeignKeyConstraint(
-            ['domain_type', 'domain_name', 'controller_name'],
-            ['aim_vmm_controllers.domain_type',
-             'aim_vmm_controllers.domain_name',
-             'aim_vmm_controllers.name'],
-            name='fk_inj_ns_vmm_controller'))
+                 'domain_type', 'domain_name', 'controller_name', 'name'))
 
     op.create_table(
         'aim_vmm_inj_deployments',
@@ -175,13 +169,7 @@ def upgrade():
                             'name',
                             name='uniq_aim_vmm_inj_hosts_identity'),
         sa.Index('idx_aim_vmm_inj_hosts_identity',
-                 'domain_type', 'domain_name', 'controller_name', 'name'),
-        sa.ForeignKeyConstraint(
-            ['domain_type', 'domain_name', 'controller_name'],
-            ['aim_vmm_controllers.domain_type',
-             'aim_vmm_controllers.domain_name',
-             'aim_vmm_controllers.name'],
-            name='fk_inj_host_vmm_controller'))
+                 'domain_type', 'domain_name', 'controller_name', 'name'))
 
     op.create_table(
         'aim_vmm_inj_service_ports',

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -708,12 +708,6 @@ class VmmInjectedNamespace(model_base.Base, model_base.HasAimId,
     __table_args__ = (
         model_base.uniq_column(__tablename__, 'domain_type', 'domain_name',
                                'controller_name', 'name') +
-        (sa.ForeignKeyConstraint(
-            ['domain_type', 'domain_name', 'controller_name'],
-            ['aim_vmm_controllers.domain_type',
-             'aim_vmm_controllers.domain_name',
-             'aim_vmm_controllers.name'],
-            name='fk_inj_ns_vmm_controller'),) +
         model_base.to_tuple(model_base.Base.__table_args__))
 
     domain_type = model_base.name_column(nullable=False)
@@ -874,12 +868,6 @@ class VmmInjectedHost(model_base.Base, model_base.HasAimId,
     __table_args__ = (
         model_base.uniq_column(__tablename__, 'domain_type', 'domain_name',
                                'controller_name', 'name') +
-        (sa.ForeignKeyConstraint(
-            ['domain_type', 'domain_name', 'controller_name'],
-            ['aim_vmm_controllers.domain_type',
-             'aim_vmm_controllers.domain_name',
-             'aim_vmm_controllers.name'],
-            name='fk_inj_host_vmm_controller'),) +
         model_base.to_tuple(model_base.Base.__table_args__))
 
     domain_type = model_base.name_column(nullable=False)

--- a/aim/tests/etc/aim.conf.test
+++ b/aim/tests/etc/aim.conf.test
@@ -1,3 +1,6 @@
+[DEFAULT]
+#debug=True
+
 [database]
 connection = 'sqlite://'
 

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1300,10 +1300,7 @@ class TestAciToAimConverterVMMController(TestAciToAimConverterBase,
     resource_type = resource.VMMController
     reverse_map_output = [
         {'resource': 'vmmCtrlrP',
-         'exceptions': {}},
-        {'resource': 'vmmInjectedCont',
-         'exceptions': {},
-         'to_resource': conv_utils.no_op_to_resource}]
+         'exceptions': {}}]
     sample_input = [_aci_obj('vmmCtrlrP',
                              dn='uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1',
                              nameAlias='CLSTR',
@@ -1314,10 +1311,7 @@ class TestAciToAimConverterVMMController(TestAciToAimConverterBase,
                     [_aci_obj('vmmCtrlrP',
                               dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cls2'),
                               nameAlias='',
-                              scope='iaas'),
-                     _aci_obj('vmmInjectedCont',
-                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cls2/'
-                                  'injcont'))]]
+                              scope='iaas')]]
     sample_output = [
         resource.VMMController(
             domain_type='Kubernetes', domain_name='k8s',
@@ -1337,10 +1331,10 @@ class TestAciToAimConverterVmmInjNamespace(TestAciToAimConverterBase,
         {'resource': 'vmmInjectedNs',
          'exceptions': {}}]
     sample_input = [_aci_obj('vmmInjectedNs',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns1]')),
                     _aci_obj('vmmInjectedNs',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns2]'),
                              nameAlias='N')]
 
@@ -1362,11 +1356,11 @@ class TestAciToAimConverterVmmInjDeployment(TestAciToAimConverterBase,
          'exceptions': {'replicas': {'converter': conv_utils.integer_str,
                                      'other': 'replicas'}}}]
     sample_input = [_aci_obj('vmmInjectedDepl',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns1]/depl-[depl1]'),
                              replicas='5'),
                     _aci_obj('vmmInjectedDepl',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns2]/depl-[depl2]'),
                              nameAlias='D')]
 
@@ -1389,11 +1383,11 @@ class TestAciToAimConverterVmmInjReplicaSet(TestAciToAimConverterBase,
         {'resource': 'vmmInjectedReplSet',
          'exceptions': {}}]
     sample_input = [_aci_obj('vmmInjectedReplSet',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns1]/rs-[set1]'),
                              deploymentName='depl1'),
                     _aci_obj('vmmInjectedReplSet',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns2]/rs-[set2]'),
                              nameAlias='RS')]
 
@@ -1424,20 +1418,20 @@ class TestAciToAimConverterVmmInjService(TestAciToAimConverterBase,
          'converter': converter.vmmInjectedSvcEp_converter,
          'exceptions': {}}]
     sample_input = [[_aci_obj('vmmInjectedSvc',
-                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                              dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                   'injcont/ns-[ns1]/svc-[svc1]'),
                               clusterIp='1.2.3.4',
                               type='loadBalancer',
                               lbIp='5.6.7.8'),
                      _aci_obj('vmmInjectedSvcPort',
-                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                              dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                   'injcont/ns-[ns1]/svc-[svc1]/'
                                   'p-https-prot-tcp-t-INT_HTTP'),
                               port='https',
                               protocol='tcp',
                               targetPort='INT_HTTP',),
                      _aci_obj('vmmInjectedSvcPort',
-                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                              dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                   'injcont/ns-[ns1]/svc-[svc1]/'
                                   'p-56-prot-udp-t-2056'),
                               port='56',
@@ -1445,15 +1439,15 @@ class TestAciToAimConverterVmmInjService(TestAciToAimConverterBase,
                               targetPort='2056',
                               nodePort='http'),
                      _aci_obj('vmmInjectedSvcEp',
-                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                              dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                   'injcont/ns-[ns1]/svc-[svc1]/ep-foo'),
                               contGrpName='foo'),
                      _aci_obj('vmmInjectedSvcEp',
-                              dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                              dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                   'injcont/ns-[ns1]/svc-[svc1]/ep-bar'),
                               contGrpName='bar')],
                     _aci_obj('vmmInjectedSvc',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns2]/svc-[svc2]'),
                              nameAlias='SVC')]
 
@@ -1485,13 +1479,13 @@ class TestAciToAimConverterVmmInjHost(TestAciToAimConverterBase,
         {'resource': 'vmmInjectedHost',
          'exceptions': {'kernel_version': {'other': 'kernelVer'}}}]
     sample_input = [_aci_obj('vmmInjectedHost',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/host-[host1]'),
                              os='Ubuntu',
                              kernelVer='4.0',
                              hostName='my.local.host'),
                     _aci_obj('vmmInjectedHost',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/host-[host2]'),
                              nameAlias='HOST')]
 
@@ -1514,13 +1508,13 @@ class TestAciToAimConverterVmmInjContGroup(TestAciToAimConverterBase,
         {'resource': 'vmmInjectedContGrp',
          'exceptions': {}}]
     sample_input = [_aci_obj('vmmInjectedContGrp',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns1]/grp-[pod1]'),
                              hostName='my.local.host',
                              computeNodeName='host1',
                              replicaSetName='rs1'),
                     _aci_obj('vmmInjectedContGrp',
-                             dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                             dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                                  'injcont/ns-[ns2]/grp-[pod2]'),
                              nameAlias='POD')]
 
@@ -2891,18 +2885,14 @@ class TestAimToAciConverterVMMController(TestAimToAciConverterBase,
                   scope='kubernetes',
                   mode='ovs',
                   rootContName='center1',
-                  hostOrIp='my.cluster.host'),
-         _aci_obj('vmmInjectedCont',
-                  dn='uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/injcont')],
+                  hostOrIp='my.cluster.host')],
         [_aci_obj('vmmCtrlrP',
                   dn='uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster2',
                   nameAlias='',
                   scope='iaas',
                   mode='k8s',
                   rootContName='cluster2',
-                  hostOrIp='cluster2'),
-         _aci_obj('vmmInjectedCont',
-                  dn='uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster2/injcont')]
+                  hostOrIp='cluster2')]
     ]
 
 
@@ -2922,11 +2912,11 @@ class TestAimToAciConverterVmmInjNamespace(TestAimToAciConverterBase,
 
     sample_output = [
         [_aci_obj('vmmInjectedNs',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]'),
                   nameAlias='NS1')],
         [_aci_obj('vmmInjectedNs',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns2]'),
                   nameAlias='')]
     ]
@@ -2949,13 +2939,13 @@ class TestAimToAciConverterVmmInjDeployment(TestAimToAciConverterBase,
 
     sample_output = [
         [_aci_obj('vmmInjectedDepl',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/depl-[depl1]'),
                   replicas='3',
                   guid='123',
                   nameAlias='DEP1')],
         [_aci_obj('vmmInjectedDepl',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/depl-[depl2]'),
                   replicas='0',
                   guid='',
@@ -2981,13 +2971,13 @@ class TestAimToAciConverterVmmInjReplicaSet(TestAimToAciConverterBase,
 
     sample_output = [
         [_aci_obj('vmmInjectedReplSet',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/rs-[set1]'),
                   nameAlias='RS1',
                   deploymentName='depl1',
                   guid='123')],
         [_aci_obj('vmmInjectedReplSet',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/rs-[set2]'),
                   nameAlias='',
                   deploymentName='',
@@ -3023,7 +3013,7 @@ class TestAimToAciConverterVmmInjService(TestAimToAciConverterBase,
 
     sample_output = [
         [_aci_obj('vmmInjectedSvc',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/svc-[svc2]'),
                   nameAlias='',
                   type='clusterIp',
@@ -3031,7 +3021,7 @@ class TestAimToAciConverterVmmInjService(TestAimToAciConverterBase,
                   clusterIp='0.0.0.0',
                   guid='')],
         [_aci_obj('vmmInjectedSvc',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/svc-[svc1]'),
                   clusterIp='1.2.3.4',
                   type='loadBalancer',
@@ -3039,7 +3029,7 @@ class TestAimToAciConverterVmmInjService(TestAimToAciConverterBase,
                   guid='123',
                   nameAlias='SVC1',),
          _aci_obj('vmmInjectedSvcPort',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/svc-[svc1]/'
                       'p-https-prot-tcp-t-INT_HTTP'),
                   port='https',
@@ -3047,7 +3037,7 @@ class TestAimToAciConverterVmmInjService(TestAimToAciConverterBase,
                   targetPort='INT_HTTP',
                   nodePort='unspecified'),
          _aci_obj('vmmInjectedSvcPort',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/svc-[svc1]/'
                       'p-56-prot-udp-t-2056'),
                   port='56',
@@ -3055,11 +3045,11 @@ class TestAimToAciConverterVmmInjService(TestAimToAciConverterBase,
                   targetPort='2056',
                   nodePort='http'),
          _aci_obj('vmmInjectedSvcEp',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/svc-[svc1]/ep-foo'),
                   contGrpName='foo'),
          _aci_obj('vmmInjectedSvcEp',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/svc-[svc1]/ep-bar'),
                   contGrpName='bar')]
     ]
@@ -3083,14 +3073,14 @@ class TestAimToAciConverterVmmInjHost(TestAimToAciConverterBase,
 
     sample_output = [
         [_aci_obj('vmmInjectedHost',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/host-[host1]'),
                   nameAlias='HOST1',
                   os='',
                   kernelVer='',
                   hostName='')],
         [_aci_obj('vmmInjectedHost',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/host-[host2]'),
                   nameAlias='',
                   os='RHEL',
@@ -3119,7 +3109,7 @@ class TestAimToAciConverterVmmInjContGroup(TestAimToAciConverterBase,
 
     sample_output = [
         [_aci_obj('vmmInjectedContGrp',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/grp-[pod1]'),
                   hostName='my.local.host',
                   computeNodeName='host1',
@@ -3127,7 +3117,7 @@ class TestAimToAciConverterVmmInjContGroup(TestAimToAciConverterBase,
                   nameAlias='POD1',
                   replicaSetName='rs1')],
         [_aci_obj('vmmInjectedContGrp',
-                  dn=('uni/vmmp-Kubernetes/dom-k8s/ctrlr-cluster1/'
+                  dn=('comp/prov-Kubernetes/ctrlr-[k8s]-cluster1/'
                       'injcont/ns-[ns1]/grp-[pod2]'),
                   hostName='',
                   computeNodeName='',

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -116,8 +116,8 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # created Kubernetes objects can be handled
         k8s_ctrlr = {'vmmInjectedCont':
                      {'attributes':
-                      {'dn': ('uni/vmmp-Kubernetes/dom-kubernetes/'
-                              'ctrlr-kube-cluster/injcont')}}}
+                      {'dn': ('comp/prov-Kubernetes/'
+                              'ctrlr-[kubernetes]-kube-cluster/injcont')}}}
         self._set_events([k8s_ctrlr], manager=self._current_manager,
                          tag=False, create_parents=True)
         # Tagging is done by the tenant manager
@@ -1039,6 +1039,8 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # Put back EPG into monitored state
         epg = self.aim_manager.update(self.ctx, epg, monitored=True)
         self.assertTrue(epg.monitored)
+        # agent._daemon_loop(self.ctx)
+        # self._observe_aci_events(current_config)
         self._sync_and_verify(agent, current_config,
                               [(desired_config, current_config),
                                (desired_monitor, current_monitor)],
@@ -1566,8 +1568,9 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         agent._daemon_loop(self.ctx)
         f1 = aim_status.AciFault(
             fault_code='F609007',
-            external_identifier='uni/vmmp-Kubernetes/dom-kubernetes/'
-                                'ctrlr-kubernetes/injcont/ns-[default]/'
+            external_identifier='comp/prov-Kubernetes/'
+                                'ctrlr-[kubernetes]-kubernetes/'
+                                'injcont/ns-[default]/'
                                 'svc-[frontend]/p-http-prot-tcp-t-80/'
                                 'fault-F609007')
         self.assertIsNotNone(self.aim_manager.create(self.ctx, f1))

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -1333,11 +1333,7 @@ def _setup_injected_object(test_obj, inj_klass, inj_attr, inj_name):
 
 class TestVmmInjectedNamespaceMixin(object):
     resource_class = resource.VmmInjectedNamespace
-    prereq_objects = [resource.VMMPolicy(type='Kubernetes'),
-                      resource.VMMDomain(type='Kubernetes', name='kubernetes'),
-                      resource.VMMController(domain_type='Kubernetes',
-                                             domain_name='kubernetes',
-                                             name='kube-cluster')]
+    prereq_objects = []
     test_identity_attributes = {'domain_type': 'Kubernetes',
                                 'domain_name': 'kubernetes',
                                 'controller_name': 'kube-cluster'}
@@ -1347,7 +1343,7 @@ class TestVmmInjectedNamespaceMixin(object):
     test_search_attributes = {}
     test_update_attributes = {'display_name': 'KUBE'}
     test_default_values = {}
-    test_dn = ('uni/vmmp-Kubernetes/dom-kubernetes/ctrlr-kube-cluster/injcont/'
+    test_dn = ('comp/prov-Kubernetes/ctrlr-[kubernetes]-kube-cluster/injcont/'
                'ns-[{name}]')
     res_command = 'vmm-injected-namespace'
 
@@ -1359,11 +1355,6 @@ class TestVmmInjectedNamespaceMixin(object):
 class TestVmmInjectedDeploymentMixin(object):
     resource_class = resource.VmmInjectedDeployment
     prereq_objects = [
-        resource.VMMPolicy(type='Kubernetes'),
-        resource.VMMDomain(type='Kubernetes', name='kubernetes'),
-        resource.VMMController(domain_type='Kubernetes',
-                               domain_name='kubernetes',
-                               name='kube-cluster'),
         resource.VmmInjectedNamespace(domain_type='Kubernetes',
                                       domain_name='kubernetes',
                                       controller_name='kube-cluster',
@@ -1381,7 +1372,7 @@ class TestVmmInjectedDeploymentMixin(object):
     test_update_attributes = {'replicas': 2,
                               'display_name': 'DEPL'}
     test_default_values = {'replicas': 0}
-    test_dn = ('uni/vmmp-Kubernetes/dom-kubernetes/ctrlr-kube-cluster/injcont/'
+    test_dn = ('comp/prov-Kubernetes/ctrlr-[kubernetes]-kube-cluster/injcont/'
                'ns-[{namespace_name}]/depl-[depl1]')
     res_command = 'vmm-injected-deployment'
 
@@ -1393,11 +1384,6 @@ class TestVmmInjectedDeploymentMixin(object):
 class TestVmmInjectedReplicaSetMixin(object):
     resource_class = resource.VmmInjectedReplicaSet
     prereq_objects = [
-        resource.VMMPolicy(type='Kubernetes'),
-        resource.VMMDomain(type='Kubernetes', name='kubernetes'),
-        resource.VMMController(domain_type='Kubernetes',
-                               domain_name='kubernetes',
-                               name='kube-cluster'),
         resource.VmmInjectedNamespace(domain_type='Kubernetes',
                                       domain_name='kubernetes',
                                       controller_name='kube-cluster',
@@ -1414,7 +1400,7 @@ class TestVmmInjectedReplicaSetMixin(object):
     test_search_attributes = {'name': 'repl1'}
     test_update_attributes = {'display_name': 'REPL'}
     test_default_values = {}
-    test_dn = ('uni/vmmp-Kubernetes/dom-kubernetes/ctrlr-kube-cluster/injcont/'
+    test_dn = ('comp/prov-Kubernetes/ctrlr-[kubernetes]-kube-cluster/injcont/'
                'ns-[{namespace_name}]/rs-[repl1]')
     res_command = 'vmm-injected-replica-set'
 
@@ -1426,11 +1412,6 @@ class TestVmmInjectedReplicaSetMixin(object):
 class TestVmmInjectedServiceMixin(object):
     resource_class = resource.VmmInjectedService
     prereq_objects = [
-        resource.VMMPolicy(type='Kubernetes'),
-        resource.VMMDomain(type='Kubernetes', name='kubernetes'),
-        resource.VMMController(domain_type='Kubernetes',
-                               domain_name='kubernetes',
-                               name='kube-cluster'),
         resource.VmmInjectedNamespace(domain_type='Kubernetes',
                                       domain_name='kubernetes',
                                       controller_name='kube-cluster',
@@ -1460,7 +1441,7 @@ class TestVmmInjectedServiceMixin(object):
                            'cluster_ip': '0.0.0.0',
                            'load_balancer_ip': '0.0.0.0',
                            'service_ports': []}
-    test_dn = ('uni/vmmp-Kubernetes/dom-kubernetes/ctrlr-kube-cluster/injcont/'
+    test_dn = ('comp/prov-Kubernetes/ctrlr-[kubernetes]-kube-cluster/injcont/'
                'ns-[{namespace_name}]/svc-[svc1]')
     res_command = 'vmm-injected-service'
 
@@ -1477,11 +1458,7 @@ class TestVmmInjectedServiceMixin(object):
 
 class TestVmmInjectedHostMixin(object):
     resource_class = resource.VmmInjectedHost
-    prereq_objects = [resource.VMMPolicy(type='Kubernetes'),
-                      resource.VMMDomain(type='Kubernetes', name='kubernetes'),
-                      resource.VMMController(domain_type='Kubernetes',
-                                             domain_name='kubernetes',
-                                             name='kube-cluster'), ]
+    prereq_objects = []
     test_identity_attributes = {'domain_type': 'Kubernetes',
                                 'domain_name': 'kubernetes',
                                 'controller_name': 'kube-cluster'}
@@ -1494,7 +1471,7 @@ class TestVmmInjectedHostMixin(object):
     test_search_attributes = {'os': 'Ubuntu'}
     test_update_attributes = {'host_name': 'host2.local.lab'}
     test_default_values = {}
-    test_dn = ('uni/vmmp-Kubernetes/dom-kubernetes/ctrlr-kube-cluster/injcont/'
+    test_dn = ('comp/prov-Kubernetes/ctrlr-[kubernetes]-kube-cluster/injcont/'
                'host-[{name}]')
     res_command = 'vmm-injected-host'
 
@@ -1506,11 +1483,6 @@ class TestVmmInjectedHostMixin(object):
 class TestVmmInjectedContGroupMixin(object):
     resource_class = resource.VmmInjectedContGroup
     prereq_objects = [
-        resource.VMMPolicy(type='Kubernetes'),
-        resource.VMMDomain(type='Kubernetes', name='kubernetes'),
-        resource.VMMController(domain_type='Kubernetes',
-                               domain_name='kubernetes',
-                               name='kube-cluster'),
         resource.VmmInjectedNamespace(domain_type='Kubernetes',
                                       domain_name='kubernetes',
                                       controller_name='kube-cluster',
@@ -1529,7 +1501,7 @@ class TestVmmInjectedContGroupMixin(object):
     test_search_attributes = {'name': 'pod1'}
     test_update_attributes = {'display_name': 'POD'}
     test_default_values = {'host_name': ''}
-    test_dn = ('uni/vmmp-Kubernetes/dom-kubernetes/ctrlr-kube-cluster/injcont/'
+    test_dn = ('comp/prov-Kubernetes/ctrlr-[kubernetes]-kube-cluster/injcont/'
                'ns-[{namespace_name}]/grp-[pod1]')
     res_command = 'vmm-injected-cont-group'
 

--- a/aim/tests/unit/test_structured_hash_tree.py
+++ b/aim/tests/unit/test_structured_hash_tree.py
@@ -963,17 +963,12 @@ class TestTreeBuilder(base.TestAimDBBase):
                                                  'domain_type': 'Kubernetes',
                                                  'guid': 'a',
                                                  'namespace_name': 'k'})
-        ctrlr = resource.VMMController(**{'monitored': False,
-                                          'name': 'kube',
-                                          'domain_name': 'kube',
-                                          'domain_type': 'Kubernetes',
-                                          'host_or_ip': 'k8s-host',
-                                          'mode': 'k8s',
-                                          'scope': 'kubernetes',
-                                          'root_cont_name': 'k',
-                                          'display_name': ''})
-
-        updates = [depl, ctrlr, ctrlr]
+        ns = resource.VmmInjectedNamespace(**{'display_name': '',
+                                              'name': 'k',
+                                              'domain_name': 'kube',
+                                              'controller_name': 'kube',
+                                              'domain_type': 'Kubernetes'})
+        updates = [depl, ns, ns]
 
         mgr = aim_manager.AimManager()
 
@@ -1003,7 +998,7 @@ class TestTreeBuilder(base.TestAimDBBase):
                 self.assertIsNotNone(cfg.find(exp_key),
                                      'Resource %s' % aim_res)
                 self.assertIsNotNone(
-                    trees['config']['vmmp-Kubernetes'].find(exp_key),
+                    trees['config']['comp'].find(exp_key),
                     'Resource %s' % aim_res)
 
     def test_deleted_node(self):
@@ -1015,17 +1010,13 @@ class TestTreeBuilder(base.TestAimDBBase):
                                                  'domain_type': 'Kubernetes',
                                                  'guid': 'a',
                                                  'namespace_name': 'k'})
-        ctrlr = resource.VMMController(**{'monitored': False,
-                                          'name': 'kube',
-                                          'domain_name': 'kube',
-                                          'domain_type': 'Kubernetes',
-                                          'host_or_ip': 'k8s-host',
-                                          'mode': 'k8s',
-                                          'scope': 'kubernetes',
-                                          'root_cont_name': 'k',
-                                          'display_name': ''})
+        ns = resource.VmmInjectedNamespace(**{'display_name': '',
+                                              'name': 'k',
+                                              'domain_name': 'kube',
+                                              'controller_name': 'kube',
+                                              'domain_type': 'Kubernetes'})
 
-        updates = [depl, ctrlr]
+        updates = [depl, ns]
         mgr = aim_manager.AimManager()
         tt_maker = tree_manager.AimHashTreeMaker()
         tt_builder = tree_manager.HashTreeBuilder(mgr)
@@ -1051,8 +1042,8 @@ class TestTreeBuilder(base.TestAimDBBase):
             key = tt_maker.get_root_key(aim_res)
             _build(key, [aim_res], [])
 
-        key = tt_maker.get_root_key(ctrlr)
+        key = tt_maker.get_root_key(ns)
         if key and trees is not None:
-            _build(key, [], [ctrlr])
+            _build(key, [], [ns])
 
-        self.assertIsNotNone(trees['config']['vmmp-Kubernetes'].find(exp_key))
+        self.assertIsNotNone(trees['config']['comp'].find(exp_key))


### PR DESCRIPTION
VmmInjected objects have now moved to the compUni
tree. Also vmmInjectedCont objects are now
implicitly created by APIC, so we don't create them
during conversion anymore.

Signed-off-by: Amit Bose <amitbose@gmail.com>