### PR TITLE
Don't put objects in error state while changing monitored value

### DIFF
--- a/aim/agent/aid/service.py
+++ b/aim/agent/aid/service.py
@@ -206,7 +206,7 @@ class AID(object):
                 max(0, self.report_interval - (time.time() - start)))
 
     def _send_heartbeat(self, aim_ctx):
-        LOG.debug("Sending Heartbeat for agent %s" % self.agent_id)
+        LOG.info("Sending Heartbeat for agent %s" % self.agent_id)
         self.agent.beat_count += 1
         self.agent = self.manager.create(aim_ctx, self.agent,
                                          overwrite=True)

--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -280,8 +280,10 @@ class AciUniverse(base.HashTreeStoredUniverse):
                 try:
                     serving_tenant_copy[removed].kill()
                     serving_tenant_copy[removed]._unsubscribe_tenant()
-                except Exception:
-                    LOG.error('Killing manager failed for tenant %s' % removed)
+                except Exception as e:
+                    LOG.debug(traceback.format_exc())
+                    LOG.error('Killing manager failed for tenant %s: %s' %
+                              (removed, e.message))
                     continue
             for added in tenants:
                 if added in serving_tenant_copy:

--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 
 from aim.agent.aid.universes.aci import converter
 from aim.agent.aid.universes import base_universe as base
-from aim.agent.aid.universes import errors
 from aim.api import resource as aim_resource
 from aim.api import status as aim_status
 from aim.common import utils
@@ -215,9 +214,7 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
                 except aim_exc.InvalidMonitoredStateUpdate as e:
                     msg = ("Failed to %s object %s in AIM: %s." %
                            (method, resource, e.message))
-                    LOG.error(msg)
-                    self.creation_failed(resource, reason=e.message,
-                                         error=errors.OPERATION_CRITICAL)
+                    LOG.warn(msg)
                 except Exception as e:
                     LOG.error("Failed to %s object %s in AIM: %s." %
                               (method, resource, e.message))


### PR DESCRIPTION
Whenever an AIM object switches its monitored state, the object
is moved from the Monitored tree (current state) to the Config tree
(desired state). Doing this causes the following:

1) Configuration universe created the TAG on ACI for the object;
2) Monitored universe tries to re-create the object in AIM with
   monitored = True: this fails by design;
3) Events arrive for #1, and on the ACI universe, the object is
   now in the Config tree (current state) so on the next AID
   iteration #2 doesn't happen anymore. Everything is synced.

If #2 happens before #1 however, then the object is put in Error
state, preventing #2 from happening (the AIM monitored state of the
object is still False. So the affected tree will be the Config
even though this happened in the Monitored Universe!). This causes
divergence until the divergence control engine kicks in and surrenders
the operation.

To avoid the problem, we shouldn't put the object in error state
during #2.