### PR TITLE
Add support for multiple VMM types

### DIFF
--- a/aim/aim_lib/nat_strategy.py
+++ b/aim/aim_lib/nat_strategy.py
@@ -421,16 +421,18 @@ class NatStrategyMixin(NatStrategy):
         bd.vrf_name = l3out.vrf_name
         ap, epg = self._get_nat_ap_epg(ctx, l3out)
         vm_doms = getattr(
-            self, 'vmm_domain_names',
-            [d.name for d in self.mgr.find(ctx, resource.VMMDomain)])
+            self, 'vmm_domains',
+            [{'type': d.type, 'name': d.name} for d in
+             self.mgr.find(ctx, resource.VMMDomain)])
         phy_doms = getattr(
-            self, 'physical_domain_names',
-            [d.name for d in self.mgr.find(ctx, resource.PhysicalDomain)])
+            self, 'physical_domains',
+            [{'name': d.name} for d in
+             self.mgr.find(ctx, resource.PhysicalDomain)])
         epg.bd_name = bd.name
         epg.provided_contract_names = [contract.name]
         epg.consumed_contract_names = [contract.name]
-        epg.openstack_vmm_domain_names = vm_doms
-        epg.physical_domain_names = phy_doms
+        epg.vmm_domains = vm_doms
+        epg.physical_domains = phy_doms
         return [fltr, entry, contract, subject, bd, ap, epg]
 
     def _create_nat_epg(self, ctx, l3out):

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -367,6 +367,8 @@ class EndpointGroup(AciResourceBase):
         ('consumed_contract_names', t.list_of_names),
         ('openstack_vmm_domain_names', t.list_of_names),
         ('physical_domain_names', t.list_of_names),
+        ('vmm_domains', t.list_of_dicts(('type', t.name), ('name', t.name))),
+        ('physical_domains', t.list_of_dicts(('name', t.name))),
         ('static_paths', t.list_of_static_paths),
         ('monitored', t.bool))
 
@@ -382,6 +384,8 @@ class EndpointGroup(AciResourceBase):
                                              'consumed_contract_names': [],
                                              'openstack_vmm_domain_names': [],
                                              'physical_domain_names': [],
+                                             'vmm_domains': [],
+                                             'physical_domains': [],
                                              'policy_enforcement_pref':
                                              self.POLICY_UNENFORCED,
                                              'static_paths': [],

--- a/aim/common/utils.py
+++ b/aim/common/utils.py
@@ -34,6 +34,9 @@ from oslo_log import log as logging
 LOG = logging.getLogger(__name__)
 AIM_LOCK_PREFIX = 'aim_lock'
 OPENSTACK_VMM_TYPE = 'OpenStack'
+VMWARE_VMM_TYPE = 'VMware'
+KNOWN_VMM_TYPES = {'openstack': OPENSTACK_VMM_TYPE,
+                   'vmware': VMWARE_VMM_TYPE}
 ACI_FAULT = 'faultInst'
 
 

--- a/aim/tests/etc/aim.conf.test
+++ b/aim/tests/etc/aim.conf.test
@@ -32,3 +32,11 @@ aim_system_id = openstack_aid
 [apic_vmdom:ostack]
 
 [apic_vmdom:ostack2]
+apic_vmm_type=OpenStack
+
+[apic_vmdom:vmware]
+apic_vmm_type=vmware
+
+[apic_vmdom:vmware2]
+apic_vmm_type=VMware
+

--- a/aim/tests/unit/aim_lib/test_nat_strategy.py
+++ b/aim/tests/unit/aim_lib/test_nat_strategy.py
@@ -94,8 +94,15 @@ class TestNatStrategyBase(object):
                                 bd_name=name,
                                 provided_contract_names=[name],
                                 consumed_contract_names=[name],
+                                # NOTE(ivar): Need to keep both VMM
+                                # representations since a GET on the EPG
+                                # will also return the domain name list
+                                # for backward compatibility
                                 openstack_vmm_domain_names=['ostack'],
-                                physical_domain_names=['phys'])] +
+                                physical_domain_names=['phys'],
+                                vmm_domains=[{'type': 'OpenStack',
+                                              'name': 'ostack'}],
+                                physical_domains=[{'name': 'phys'}])] +
                 ([nat_vrf] if nat_vrf_name is None else []))
 
     @base.requires(['foreign_keys'])

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -636,7 +636,8 @@ class TestEndpointGroupMixin(object):
                                                  {'path': 'topology/pod-1/'
                                                           'paths-102/pathep-'
                                                           '[eth1/5]',
-                                                  'encap': 'vlan-5'}]}
+                                                  'encap': 'vlan-5'}],
+                                'physical_domains': [{'name': 'phys'}]}
     test_search_attributes = {'name': 'web'}
     test_update_attributes = {'bd_name': 'net1',
                               'policy_enforcement_pref':
@@ -1712,6 +1713,8 @@ class TestEndpointGroup(TestEndpointGroupMixin, TestAciResourceOpsBase,
                          getattr_canonical(r0, 'provided_contract_names'))
         self.assertEqual(['openstack'],
                          getattr_canonical(r0, 'openstack_vmm_domain_names'))
+        self.assertEqual([{'type': 'OpenStack', 'name': 'openstack'}],
+                         getattr_canonical(r0, 'vmm_domains'))
 
         r1 = self.mgr.update(self.ctx, res, bd_name='net1')
         self.assertEqual('net1', r1.bd_name)
@@ -1721,13 +1724,15 @@ class TestEndpointGroup(TestEndpointGroupMixin, TestAciResourceOpsBase,
                          getattr_canonical(r1, 'consumed_contract_names'))
 
         r2 = self.mgr.update(self.ctx, res, provided_contract_names=[],
-                             openstack_vmm_domain_names=[])
+                             vmm_domains=[])
         self.assertEqual('net1', r2.bd_name)
         self.assertEqual([], getattr_canonical(r2, 'provided_contract_names'))
         self.assertEqual(['c1', 'c2', 'k'],
                          getattr_canonical(r2, 'consumed_contract_names'))
         self.assertEqual([],
                          getattr_canonical(r2, 'openstack_vmm_domain_names'))
+        self.assertEqual([],
+                         getattr_canonical(r2, 'vmm_domains'))
 
 
 class TestFilter(TestFilterMixin, TestAciResourceOpsBase, base.TestAimDBBase):


### PR DESCRIPTION
Two new attributes are added to the EPG resource:

- vmm_domains: list of dictionaries describing VMMs to which the
EPG refers to;
- physical_domains: list of dictionaries describing physdoms to
which the EPG refers to.

right now, only name and type (in the case of VMM) can be specified.
In future, we can add extra attributes to custom VMM capabilities.
the old attributes 'physical_domain_names' and 'openstack_vmm_names'
are still around and can be used both for reading and writing
new references, but their value will be mirrored in the vmm_domains
and physical_domains attributes.