### PR TITLE
Add config option to disable micro-segmentation

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -27,6 +27,7 @@ from aim.api import resource
 from aim.api import status as aim_status
 from aim.api import types as t
 from aim.common import utils as aim_utils
+from aim import config as aim_cfg
 
 LOG = logging.getLogger(__name__)
 DELETED_STATUS = "deleted"
@@ -153,8 +154,10 @@ def fv_rs_dom_att_converter(object_dict, otype, helper,
                 aci_mo_type='fvRsDomAtt', to_aim=False)[0]
             dom_ref = {'fvRsDomAtt': {'attributes': {'dn': dn,
                                                      'tDn': vmm_dn,
-                                                     'classPref': 'useg',
                                                      'instrImedcy': 'lazy'}}}
+            if not aim_cfg.CONF.aim.disable_micro_segmentation:
+                dom_ref['fvRsDomAtt']['attributes'].update({'classPref':
+                                                            'useg'})
             if vmm[0].lower() == aim_utils.VMWARE_VMM_TYPE.lower():
                 dom_ref['fvRsDomAtt']['attributes'][
                     'instrImedcy'] = 'immediate'

--- a/aim/config.py
+++ b/aim/config.py
@@ -56,6 +56,10 @@ agent_opts = [
     cfg.BoolOpt('poll_config', default=False,
                 help=("Check whether to run the configuration poller or "
                       "not.")),
+    cfg.BoolOpt('disable_micro_segmentation', default=False,
+                help=("Set 'Allow Micro-Segmentation' flag to 'False' when "
+                      "associating VMM Domains with EPGs. This is needed "
+                      "when the hardware doesn't support this feature.")),
     cfg.StrOpt('aim_system_id', required=True, default='openstack_aid',
                help="Identifier of the AIM system used to mark object "
                     "ownership in ACI"),

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -23,6 +23,7 @@ from aim.api import infra as aim_infra
 from aim.api import resource
 from aim.api import service_graph as aim_service_graph
 from aim.api import status as aim_status
+from aim import config as aim_cfg
 from aim.tests import base
 
 
@@ -1886,6 +1887,17 @@ class TestAimToAciConverterEPG(TestAimToAciConverterBase, base.TestAimDBBase):
         "fvAEPg": {"attributes": {"dn": "uni/tn-t1/ap-a1/epg-test",
                                   "pcEnfPref": "unenforced",
                                   "nameAlias": ""}}}]
+
+
+class TestAimToAciConverterEPGNoUseg(TestAimToAciConverterEPG):
+    def setUp(self):
+        super(TestAimToAciConverterEPGNoUseg, self).setUp()
+        for tll in self.sample_output:
+            for tla in tll:
+                if 'fvRsDomAtt' in tla:
+                    if 'classPref' in tla['fvRsDomAtt']['attributes']:
+                        del(tla['fvRsDomAtt']['attributes']['classPref'])
+        aim_cfg.CONF.set_override('disable_micro_segmentation', True, 'aim')
 
 
 class TestAimToAciConverterFault(TestAimToAciConverterBase,


### PR DESCRIPTION
Some situations, such as older switch hardware, require us to have
the ability to disable configuration of Micro-Segmentation support
on the VMM domain associations with EPGs. This patch adds that
configuration option, which removes this attribute from APIC
configuration when associating VMM Domains with EPGs.