### PR TITLE
Also return interface_name and pod_id in get_switch_and_port_for_host()

### DIFF
--- a/aim/db/infra_model.py
+++ b/aim/db/infra_model.py
@@ -44,7 +44,7 @@ class HostLinkManager(object):
         self.aim_manager = aim_manager
 
     def add_hostlink(self, host, ifname, ifmac, swid, module,
-                     port, path, pod_id=1, from_config=False):
+                     port, path, pod_id='1', from_config=False):
         link = infra.HostLink(
             host_name=host, interface_name=ifname,
             interface_mac=ifmac, switch_id=swid, module=module,
@@ -104,7 +104,8 @@ class HostLinkManager(object):
 
     def get_switch_and_port_for_host(self, host):
         res = self.get_hostlinks_for_host(host)
-        return list(set([(x.switch_id, x.module, x.port) for x in res]))
+        return list(set([(x.switch_id, x.module, x.port,
+                          x.interface_name, x.pod_id) for x in res]))
 
 
 class OpflexDevice(model_base.Base, model_base.AttributeMixin,

--- a/aim/tests/unit/test_infra_manager.py
+++ b/aim/tests/unit/test_infra_manager.py
@@ -71,7 +71,9 @@ class TestAimInfraManager(base.TestAimDBBase):
 
         hlinks = self.infra_mgr.get_switch_and_port_for_host(host)
         self.assertEqual(hlinks[0], (hlinks_mgr[0].switch_id,
-                                     hlinks_mgr[0].module, hlinks_mgr[0].port))
+                                     hlinks_mgr[0].module, hlinks_mgr[0].port,
+                                     hlinks_mgr[0].interface_name,
+                                     hlinks_mgr[0].pod_id))
         # Verify overwrite
         port2 = 3
         self.infra_mgr.add_hostlink(


### PR DESCRIPTION
They are needed now once we start to allow different
interface_name and pod_id.