### PR TITLE
Properly skipp root deletion for monitored objects

### DIFF
--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -336,3 +336,19 @@ class AimDbMonitoredUniverse(AimDbUniverse):
         self._set_sync_pending_state(add_diff, raw_diff, other_universe,
                                      skip_roots=skip_roots)
         self._set_synced_state(my_state, raw_diff, skip_roots=skip_roots)
+
+    def get_resources_for_delete(self, resource_keys):
+        des_mon = self.multiverse[base.MONITOR_UNIVERSE]['desired'].state
+
+        def action(result, aci_object, node):
+            key = tree_manager.AimHashTreeMaker._dn_to_key(
+                aci_object.keys()[0],
+                aci_object.values()[0]['attributes']['dn'])
+            if len(key) == 1:
+                LOG.debug('Skipping delete for monitored root object: %s '
+                          % aci_object)
+                return
+            if not node or node.dummy:
+                result.append(aci_object)
+        return self._converter.convert(
+            self._get_resources_for_delete(resource_keys, des_mon, action))


### PR DESCRIPTION
Today, the monitored universe skips the deletion of root objects
with a warning message that can often be confused with actual divergence.
On top of that, the action cache logs all these deletion attempts as
if they were part of an unfixable divergence. We should skip the
deletion at a previous time in the reconciliation cycle, so that
AID still doesn't "smile" (after all, we are monitoring a
non-existent object) but so that we don't cause divergence either.