### PR TITLE
Fix the foreign key error while running the migration script.

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -647,7 +647,8 @@ resource_map = {
     }],
     'l3extRsNodeL3OutAtt': [{
         'resource': resource.L3OutNode,
-        'exceptions': {'rtrId': {'other': 'router_id'}}
+        'exceptions': {'rtrId': {'other': 'router_id'},
+                       'rtrIdLoopBack': {'other': 'router_id_loopback'}}
     }],
     'ipRouteP': [{
         'resource': resource.L3OutStaticRoute,

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -705,6 +705,7 @@ class L3OutNode(AciResourceBase):
         ('node_path', t.string()))
     other_attributes = t.other(
         ('router_id', t.ipv4),
+        ('router_id_loopback', t.bool),
         ('monitored', t.bool))
 
     _aci_mo_name = 'l3extRsNodeL3OutAtt'
@@ -712,7 +713,8 @@ class L3OutNode(AciResourceBase):
 
     def __init__(self, **kwargs):
         super(L3OutNode, self).__init__(
-            {'router_id': '', 'monitored': False}, **kwargs)
+            {'router_id': '', 'router_id_loopback': True,
+             'monitored': False}, **kwargs)
 
 
 class L3OutStaticRoute(AciResourceBase):

--- a/aim/db/migration/alembic_migrations/versions/6d55c6f80f40_svi.py
+++ b/aim/db/migration/alembic_migrations/versions/6d55c6f80f40_svi.py
@@ -43,13 +43,13 @@ def upgrade():
         sa.Column('monitored', sa.Boolean, nullable=False, default=False),
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'l3out_name', 'name',
-                            name='uniq_aim_node_profile_identity'),
-        sa.Index('idx_aim_node_profile_identity',
+                            name='uniq_aim_l3out_node_profile_identity'),
+        sa.Index('idx_aim_l3out_node_profile_identity',
                  'tenant_name', 'l3out_name', 'name'),
         sa.ForeignKeyConstraint(
             ['tenant_name', 'l3out_name'],
             ['aim_l3outsides.tenant_name', 'aim_l3outsides.name'],
-            name='fk_np_l3out'))
+            name='fk_l3out_np_l3out'))
 
     op.create_table(
         'aim_l3out_nodes',
@@ -59,19 +59,21 @@ def upgrade():
         sa.Column('node_profile_name', sa.String(64), nullable=False),
         sa.Column('node_path', VARCHAR(512, charset='latin1'), nullable=False),
         sa.Column('router_id', sa.String(64), nullable=False),
+        sa.Column('router_id_loopback', sa.Boolean, nullable=False),
         sa.Column('monitored', sa.Boolean, nullable=False, default=False),
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'l3out_name', 'node_profile_name',
                             'node_path',
-                            name='uniq_aim_node_identity'),
-        sa.Index('idx_aim_node_identity',
+                            name='uniq_aim_l3out_node_identity'),
+        sa.Index('idx_aim_l3out_node_identity',
                  'tenant_name', 'l3out_name', 'node_profile_name',
                  'node_path'),
         sa.ForeignKeyConstraint(
             ['tenant_name', 'l3out_name', 'node_profile_name'],
-            ['aim_node_profiles.tenant_name', 'aim_node_profiles.l3out_name',
-             'aim_node_profiles.name'],
-            name='fk_node_pofile'))
+            ['aim_l3out_node_profiles.tenant_name',
+             'aim_l3out_node_profiles.l3out_name',
+             'aim_l3out_node_profiles.name'],
+            name='fk_l3out_node_pofile'))
 
     op.create_table(
         'aim_l3out_static_routes',
@@ -87,15 +89,16 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'l3out_name', 'node_profile_name',
                             'node_path', 'cidr',
-                            name='uniq_aim_static_route_identity'),
-        sa.Index('idx_aim_static_route_identity',
+                            name='uniq_aim_l3out_static_route_identity'),
+        sa.Index('idx_aim_l3out_static_route_identity',
                  'tenant_name', 'l3out_name', 'node_profile_name',
                  'node_path', 'cidr'),
         sa.ForeignKeyConstraint(
             ['tenant_name', 'l3out_name', 'node_profile_name', 'node_path'],
-            ['aim_nodes.tenant_name', 'aim_nodes.l3out_name',
-             'aim_nodes.node_profile_name', 'aim_nodes.node_path'],
-            name='fk_node'))
+            ['aim_l3out_nodes.tenant_name', 'aim_l3out_nodes.l3out_name',
+             'aim_l3out_nodes.node_profile_name',
+             'aim_l3out_nodes.node_path'],
+            name='fk_l3out_node'))
 
     op.create_table(
         'aim_l3out_next_hops',
@@ -104,7 +107,7 @@ def upgrade():
         sa.Column('preference', sa.String(16), nullable=False),
         sa.PrimaryKeyConstraint('static_route_aim_id', 'addr'),
         sa.ForeignKeyConstraint(
-            ['static_route_aim_id'], ['aim_static_routes.aim_id']))
+            ['static_route_aim_id'], ['aim_l3out_static_routes.aim_id']))
 
     op.create_table(
         'aim_l3out_interface_profiles',
@@ -118,15 +121,16 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'l3out_name', 'node_profile_name',
                             'name',
-                            name='uniq_aim_if_profile_identity'),
-        sa.Index('idx_aim_if_profile_identity',
+                            name='uniq_aim_l3out_if_profile_identity'),
+        sa.Index('idx_aim_l3out_if_profile_identity',
                  'tenant_name', 'l3out_name', 'node_profile_name',
                  'name'),
         sa.ForeignKeyConstraint(
             ['tenant_name', 'l3out_name', 'node_profile_name'],
-            ['aim_node_profiles.tenant_name', 'aim_node_profiles.l3out_name',
-             'aim_node_profiles.name'],
-            name='fk_if_node_pofile'))
+            ['aim_l3out_node_profiles.tenant_name',
+             'aim_l3out_node_profiles.l3out_name',
+             'aim_l3out_node_profiles.name'],
+            name='fk_l3out_if_node_pofile'))
 
     op.create_table(
         'aim_l3out_interfaces',
@@ -145,18 +149,18 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'l3out_name', 'node_profile_name',
                             'interface_profile_name', 'interface_path',
-                            name='uniq_aim_if_identity'),
-        sa.Index('idx_aim_if_identity',
+                            name='uniq_aim_l3out_if_identity'),
+        sa.Index('idx_aim_l3out_if_identity',
                  'tenant_name', 'l3out_name', 'node_profile_name',
                  'interface_profile_name', 'interface_path'),
         sa.ForeignKeyConstraint(
             ['tenant_name', 'l3out_name', 'node_profile_name',
              'interface_profile_name'],
-            ['aim_interface_profiles.tenant_name',
-             'aim_interface_profiles.l3out_name',
-             'aim_interface_profiles.node_profile_name',
-             'aim_interface_profiles.name'],
-            name='fk_interface_profile'))
+            ['aim_l3out_interface_profiles.tenant_name',
+             'aim_l3out_interface_profiles.l3out_name',
+             'aim_l3out_interface_profiles.node_profile_name',
+             'aim_l3out_interface_profiles.name'],
+            name='fk_l3out_interface_profile'))
 
     op.create_table(
         'aim_l3out_interface_secondary_ip_a',
@@ -164,7 +168,7 @@ def upgrade():
         sa.Column('addr', sa.String(64), nullable=False),
         sa.PrimaryKeyConstraint('interface_aim_id', 'addr'),
         sa.ForeignKeyConstraint(
-            ['interface_aim_id'], ['aim_interfaces.aim_id']))
+            ['interface_aim_id'], ['aim_l3out_interfaces.aim_id']))
 
     op.create_table(
         'aim_l3out_interface_secondary_ip_b',
@@ -172,7 +176,7 @@ def upgrade():
         sa.Column('addr', sa.String(64), nullable=False),
         sa.PrimaryKeyConstraint('interface_aim_id', 'addr'),
         sa.ForeignKeyConstraint(
-            ['interface_aim_id'], ['aim_interfaces.aim_id']))
+            ['interface_aim_id'], ['aim_l3out_interfaces.aim_id']))
 
 
 def downgrade():

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -560,6 +560,7 @@ class L3OutNode(model_base.Base, model_base.HasAimId,
     # on the length of primary keys
     node_path = sa.Column(VARCHAR(512, charset='latin1'), nullable=False)
     router_id = sa.Column(sa.String(64), nullable=False)
+    router_id_loopback = sa.Column(sa.Boolean, nullable=False)
 
 
 class L3OutNextHop(model_base.Base):

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -770,6 +770,7 @@ class TestAciToAimConverterL3OutNodeProfile(TestAciToAimConverterBase,
 
 def get_example_l3out_aci_node(**kwargs):
     attr = {'rtrId': '9.9.9.9',
+            'rtrIdLoopBack': True,
             'dn': 'uni/tn-t1/out-o1/lnodep-np1/rsnodeL3OutAtt-'
                   '[topology/pod-1/node-101]'}
     attr.update(**kwargs)
@@ -781,21 +782,25 @@ class TestAciToAimConverterL3OutNode(TestAciToAimConverterBase,
     resource_type = resource.L3OutNode
     reverse_map_output = [
         {'resource': 'l3extRsNodeL3OutAtt',
-         'exceptions': {'router_id': {'other': 'rtrId'}}}]
+         'exceptions': {'router_id': {'other': 'rtrId'},
+                        'router_id_loopback': {'other': 'rtrIdLoopBack'}}}]
     sample_input = [get_example_l3out_aci_node(),
                     get_example_l3out_aci_node(
                         rtrId='8.8.8.8',
+                        rtrIdLoopBack=False,
                         dn='uni/tn-t1/out-o1/lnodep-np1/rsnodeL3OutAtt-'
                            '[topology/pod-1/node-201]')]
     sample_output = [
         resource.L3OutNode(tenant_name='t1', l3out_name='o1',
                            node_profile_name='np1',
                            node_path='topology/pod-1/node-101',
-                           router_id='9.9.9.9'),
+                           router_id='9.9.9.9',
+                           router_id_loopback=True),
         resource.L3OutNode(tenant_name='t1', l3out_name='o1',
                            node_profile_name='np1',
                            node_path='topology/pod-1/node-201',
-                           router_id='8.8.8.8')]
+                           router_id='8.8.8.8',
+                           router_id_loopback=False)]
 
 
 def get_example_aci_l3out_static_route(**kwargs):
@@ -2375,7 +2380,8 @@ def get_example_aim_l3out_node(**kwargs):
     example = resource.L3OutNode(tenant_name='t1', l3out_name='l1',
                                  node_profile_name='np1',
                                  node_path='topology/pod-1/node-101',
-                                 router_id='9.9.9.9')
+                                 router_id='9.9.9.9',
+                                 router_id_loopback=True)
     example.__dict__.update(kwargs)
     return example
 
@@ -2385,7 +2391,8 @@ class TestAimToAciConverterL3OutNode(TestAimToAciConverterBase,
     sample_input = [
         get_example_aim_l3out_node(
             node_path='topology/pod-1/node-201',
-            router_id='8.8.8.8'),
+            router_id='8.8.8.8',
+            router_id_loopback=False),
         get_example_aim_l3out_node(
             pre_existing=True),
         get_example_aim_l3out_node(
@@ -2394,18 +2401,21 @@ class TestAimToAciConverterL3OutNode(TestAimToAciConverterBase,
         [_aci_obj('l3extRsNodeL3OutAtt',
                   dn='uni/tn-t1/out-l1/lnodep-np1/rsnodeL3OutAtt-'
                      '[topology/pod-1/node-201]',
-                  rtrId='8.8.8.8')],
+                  rtrId='8.8.8.8',
+                  rtrIdLoopBack=False)],
         [],
         [_aci_obj('l3extRsNodeL3OutAtt',
                   dn='uni/tn-t1/out-l1/lnodep-np1/rsnodeL3OutAtt-'
                      '[topology/pod-1/node-101]',
-                  rtrId='9.9.9.9')]]
+                  rtrId='9.9.9.9',
+                  rtrIdLoopBack=True)]]
     missing_ref_input = get_example_aim_l3out_node()
     missing_ref_output = [_aci_obj('l3extRsNodeL3OutAtt',
                                    dn='uni/tn-t1/out-l1/lnodep-np1/'
                                       'rsnodeL3OutAtt-'
                                       '[topology/pod-1/node-101]',
-                                   rtrId='9.9.9.9')]
+                                   rtrId='9.9.9.9',
+                                   rtrIdLoopBack=True)]
 
 
 def get_example_aim_l3out_static_route(**kwargs):

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -910,9 +910,11 @@ class TestL3OutNodeMixin(object):
                                 'l3out_name': 'l3out1',
                                 'node_profile_name': 'np1',
                                 'node_path': 'topology/pod-1/node-101',
-                                'router_id': '1.1.1.1'}
+                                'router_id': '1.1.1.1',
+                                'router_id_loopback': True}
     test_search_attributes = {'node_path': 'topology/pod-1/node-101'}
-    test_update_attributes = {'router_id': '2.1.1.1'}
+    test_update_attributes = {'router_id': '2.1.1.1',
+                              'router_id_loopback': False}
     test_default_values = {}
     test_dn = ("uni/tn-tenant1/out-l3out1/lnodep-np1/rsnodeL3OutAtt-"
                "[topology/pod-1/node-101]")


### PR DESCRIPTION
1. This was introduced in the last patch while addressing the review comment
to change the naming of those tables. Apparently pep8 UT won't be able to
catch this kind of errors.
2. Also add the rtrIdLoopBack attribute to the model. This is due to the fact
that starting in APIC Euphrates image, it doesn't allow "use router Id as the
loopback addr" checkbox to be checked for the same node but under a different
l3out.