### PR TITLE
Change tenant removal algorithm.

### DIFF
--- a/aim/agent/aid/universes/base_universe.py
+++ b/aim/agent/aid/universes/base_universe.py
@@ -211,6 +211,34 @@ class AimUniverse(BaseUniverse):
         """
 
     @abc.abstractmethod
+    def vote_deletion_candidates(self, other_universe, delete_candidates,
+                                 vetoes):
+        """Vote deletion candidates
+
+        Decide whether the cleanup process should be initiated for a specific
+        candidate.
+
+        :param other_universe
+        :param delete_candidates: set that each universe can use to
+               vote for tenant deletion.
+        :param
+        :return:
+        """
+
+    @abc.abstractmethod
+    def finalize_deletion_candidates(self, other_universe, delete_candidates):
+        """Finalize deletion candidates
+
+        After one reconciliation cycle, decide whether the tenant should be
+        completely deleted. Universes can only *remove* candidates at this
+        point from the list.
+
+        :param other_universe:
+        :param delete_candidates:
+        :return:
+        """
+
+    @abc.abstractmethod
     def update_status_objects(self, my_state, other_universe, other_state,
                               raw_diff, transformed_diff, skip_roots=None):
         """Update status objects
@@ -306,26 +334,28 @@ class HashTreeStoredUniverse(AimUniverse):
             aci_objects.append(aci_object)
         return aci_objects
 
+    def _mask_tenant_state(self, other_universe, delete_candidates):
+        for tenant in delete_candidates:
+            if tenant in other_universe.state:
+                other_universe.state[tenant] = (
+                    structured_tree.StructuredHashTree())
+
     def observe(self):
         pass
 
     def reconcile(self, other_universe, delete_candidates):
         return self._reconcile(other_universe, delete_candidates)
 
-    def _vote_tenant_for_deletion(self, other_universe, tenant,
-                                  delete_candidates):
-        votes = delete_candidates.setdefault(tenant, set())
-        votes.add(self)
+    def vote_deletion_candidates(self, other_universe, delete_candidates,
+                                 vetoes):
+        pass
 
-    def _reconcile(self, other_universe, delete_candidates,
-                   skip_dummy=False, always_vote_deletion=False):
+    def finalize_deletion_candidates(self, other_universe, delete_candidates):
+        pass
+
+    def _reconcile(self, other_universe, delete_candidates):
         # "self" is always the current state, "other" the desired
         my_state = self.state
-        # TODO(ivar): We used get_optimized_state method here. By doing that
-        # however, we can't identify what items need to be set in synced state
-        # to improve performance, get_optimized_state should return both
-        # different tenants and those with at least one hashtree node in
-        # pending state.
         other_state = other_universe.state
         differences = {CREATE: [], DELETE: []}
         for tenant in set(my_state.keys()) & set(other_state.keys()):
@@ -339,22 +369,6 @@ class HashTreeStoredUniverse(AimUniverse):
             if difference['add'] or difference['remove']:
                 LOG.info("Universes %s and %s have differences for tenant "
                          "%s" % (self.name, other_universe.name, tenant))
-        # Remove empty tenants
-        for tenant, tree in my_state.iteritems():
-            if always_vote_deletion or (
-                    skip_dummy and (not tree.root or tree.root.dummy)):
-                LOG.debug("%s voting for removal of tenant %s" %
-                          (self.name, tenant))
-                self._vote_tenant_for_deletion(other_universe, tenant,
-                                               delete_candidates)
-                continue
-            if not tree.root:  # A Tenant has no state
-                if tenant not in other_state or not other_state[tenant].root:
-                    self._vote_tenant_for_deletion(
-                        other_universe, tenant, delete_candidates)
-                else:
-                    # This universe disagrees on deletion
-                    delete_candidates.get(tenant, set()).discard(self)
 
         if not differences.get(CREATE) and not differences.get(DELETE):
             LOG.debug("Universe %s and %s are in sync." %

--- a/aim/aim_store.py
+++ b/aim/aim_store.py
@@ -183,7 +183,7 @@ class AimStore(object):
                        self.extract_attributes(resource))
         return obj
 
-    def fix_session(self, error):
+    def fix_session(self, error, force=False):
         pass
 
 
@@ -367,9 +367,10 @@ class SqlAlchemyStore(AimStore):
     def to_attr(self, resource_klass, db_obj):
         return db_obj.to_attr(self.db_session)
 
-    def fix_session(self, error):
-        LOG.debug("Rolling back session after %s", error.message)
-        if isinstance(error, db_exc.DBError):
+    def fix_session(self, error, force=False):
+        if error:
+            LOG.debug("Rolling back session after %s", error.message)
+        if force or isinstance(error, db_exc.DBError):
             try:
                 self.db_session.rollback()
             except Exception as e:

--- a/aim/common/hashtree/exceptions.py
+++ b/aim/common/hashtree/exceptions.py
@@ -41,3 +41,7 @@ class MultipleRootTreeError(StructuredHashTreeException):
 
 class HashTreeNotFound(StructuredHashTreeException):
     message = "Hash Tree not found for roots %(root_rn)s"
+
+
+class HashTreeNotEmpty(StructuredHashTreeException):
+    message = "Hash Tree is not empty for roots %(root_rn)s"

--- a/aim/tests/unit/agent/aid_universes/test_aim_db_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aim_db_universe.py
@@ -265,8 +265,14 @@ class TestAimDbUniverseBase(object):
 
         aim_mgr.create(self.ctx, bd1)
         aim_mgr.set_fault(self.ctx, bd1, bd1_fault)
-        self.universe.cleanup_state('tn-t1')
+        self.assertRaises(Exception, self.universe.cleanup_state, 'tn-t1')
 
+        trees = tree_mgr.find(self.ctx, tree=tree_type)
+        # tenant still there, trees not empty.
+        self.assertEqual(1, len(trees))
+        aim_mgr.clear_fault(self.ctx, bd1_fault)
+        aim_mgr.delete(self.ctx, resource.Tenant(name='t1'), cascade=True)
+        self.universe.cleanup_state('tn-t1')
         trees = tree_mgr.find(self.ctx, tree=tree_type)
         self.assertEqual(0, len(trees))
 

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -335,8 +335,8 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
                                         vrf_name='vrf2', display_name='nice')
         self.aim_manager.create(self.ctx, bd1_tn2)
         self.aim_manager.create(self.ctx, bd1_tn1)
-        bd1_tn1_status = self.aim_manager.get_status(self.ctx, bd1_tn1)
-        bd1_tn2_status = self.aim_manager.get_status(self.ctx, bd1_tn2)
+        self.aim_manager.get_status(self.ctx, bd1_tn1)
+        self.aim_manager.get_status(self.ctx, bd1_tn2)
         self.aim_manager.set_fault(
             self.ctx, bd1_tn1, aim_status.AciFault(
                 fault_code='516',
@@ -628,9 +628,11 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         agent._daemon_loop(self.ctx)
         # Delete the tenant on AIM, agents should stop watching it
         self.aim_manager.delete(self.ctx, tn1)
-        # This loop will have a consensus for deleting Tenant tn1
         agent._daemon_loop(self.ctx)
-        # Agent will not serve such tenant anymore
+        # Agent will delete remaining objects
+        agent._daemon_loop(self.ctx)
+        self.assertTrue(tn1.rn in desired_monitor.serving_tenants)
+        # Now deletion happens
         agent._daemon_loop(self.ctx)
         self.assertTrue(tn1.rn not in desired_monitor.serving_tenants)
 


### PR DESCRIPTION
The previous algorithm for tenant removal was proved to be unreliable
in situations of high load, where there are lots of threads and race
conditions are likely. This would often cause leftover objects laying
around, since the monitored universe would keep syncing in the background
without causing the removal to cease.

With the new algorithm, we have a two phase decision that is taken
before and after the reconciliation cycle. Furthermore, we make sure
that the monitored universes delete all the AIM monitored objects
when they agree on tenant removal. We do so by pretending that the
desired state is empty. Only when a tenant's AIM state is completely
empty (all trees with no root) we finally cleanup the state.
DB transactionality and update lock should ensure this happens
reliably.