### PR TITLE
Improve tenant recovery mechanism

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -340,7 +340,13 @@ class AciUniverse(base.HashTreeStoredUniverse):
         LOG.warn('Reset called for roots %s' % tenants)
         for root in tenants:
             if root in serving_tenants:
-                serving_tenants[root].scheduled_reset = -1
+                try:
+                    serving_tenants[root].kill()
+                    serving_tenants[root]._unsubscribe_tenant()
+                except Exception:
+                    LOG.error(traceback.format_exc())
+                    LOG.error('Failed to reset tenant %s' % root)
+                serving_tenants.pop(root, None)
 
     def push_resources(self, resources):
         # Organize by tenant, and push into APIC


### PR DESCRIPTION
When resetting the ACI tenants, sometimes the thread could be hanging
and scheduling a tree reset woulnd't be enough. Kill the tenant thread
and garbage collect the tenant handler instead, so that AID can
re-provision it on the next iteration and hopefully be able to
properly sync.