### PR TITLE
Also handle the case when l3extIp__Member comes.

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -285,7 +285,7 @@ def l3ext_ip_converter(object_dict, otype, helper,
         for index, attr in enumerate(destination_identity_attributes):
             res_dict[attr] = id[index]
         if object_dict.get('addr'):
-            if is_vpc:
+            if is_vpc or otype == 'l3extIp__Member':
                 if id[5] == 'A':
                     res_dict['secondary_addr_a_list'] = [{'addr':
                                                          object_dict['addr']}]
@@ -326,8 +326,8 @@ def l3ext_ip_converter(object_dict, otype, helper,
                     dn = default_identity_converter(
                         object_dict, otype, helper,
                         extra_attributes=[p['addr']],
-                        aci_mo_type=helper['resource'], to_aim=False)[0]
-                    result.append({helper['resource']: {
+                        aci_mo_type='l3extIp', to_aim=False)[0]
+                    result.append({'l3extIp': {
                         'attributes': {'dn': dn,
                                        'addr': p['addr']}}})
     return result
@@ -725,6 +725,10 @@ resource_map = {
         'skip': ['asn']
     }],
     'l3extIp': [{
+        'resource': resource.L3OutInterface,
+        'converter': l3ext_ip_converter,
+    }],
+    'l3extIp__Member': [{
         'resource': resource.L3OutInterface,
         'converter': l3ext_ip_converter,
     }],

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -911,6 +911,9 @@ class TestAciToAimConverterL3OutInterface(TestAciToAimConverterBase,
          'resource': 'l3extIp',
          'converter': converter.l3ext_ip_converter},
         {'exceptions': {},
+         'resource': 'l3extIp__Member',
+         'converter': converter.l3ext_ip_converter},
+        {'exceptions': {},
          'resource': 'l3extMember',
          'converter': converter.l3ext_member_converter}]
     sample_input = [[get_example_aci_l3out_interface(nameAlias='alias'),
@@ -952,12 +955,12 @@ class TestAciToAimConverterL3OutInterface(TestAciToAimConverterBase,
                                  'pathep-[eth1/2]]/mem-B',
                               side='B',
                               addr='1.1.1.102/24'),
-                     _aci_obj('l3extIp',
+                     _aci_obj('l3extIp__Member',
                               dn='uni/tn-t1/out-l1/lnodep-np1/lifp-ip1/'
                                  'rspathL3OutAtt-[topology/pod-1/paths-101/'
                                  'pathep-[eth1/2]]/mem-B/addr-[1.1.1.13/24]',
                               addr='1.1.1.13/24'),
-                     _aci_obj('l3extIp',
+                     _aci_obj('l3extIp__Member',
                               dn='uni/tn-t1/out-l1/lnodep-np1/lifp-ip1/'
                                  'rspathL3OutAtt-[topology/pod-1/paths-101/'
                                  'pathep-[eth1/2]]/mem-B/addr-[1.1.1.14/24]',


### PR DESCRIPTION
This will happen while doing ACI to AIM conversion for the secondary
IPs of an SVI for a VPC setup.