### PR TITLE
Add load-mappings command

### DIFF
--- a/aim/api/infra.py
+++ b/aim/api/infra.py
@@ -16,6 +16,8 @@
 from aim.api import resource
 from aim.api import types as t
 
+WILDCARD_HOST = '*'
+
 
 class HostLink(resource.ResourceBase):
     """Switch-port connection information for a host node."""


### PR DESCRIPTION
The load-mappings command is added, so that the information
specified in the configuration file can be used to create
entries in the HostDomainMappingV2 table. This patch also
adds a call to this command in the load-domains command,
so that the mappings can be created when the domains first
get loaded.