### PR TITLE
Introduce SQL optimizer

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/HEAD
+++ b/aim/db/migration/alembic_migrations/versions/HEAD
@@ -1,1 +1,1 @@
-f1ca776aafab
+1b58ffa871bb

--- a/aim/utils.py
+++ b/aim/utils.py
@@ -13,8 +13,43 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import functools
 import re
+
+from aim.api import resource
+from aim.db import models
+from aim import exceptions
+
+
+class WrongStoreType(exceptions.AimException):
+    message = "Store feature missing for this optimizer call: %(features)s."
 
 
 def sanitize_display_name(display_name):
     return re.sub(r'[^a-zA-Z0-9_.-]', '_', display_name[:59])
+
+
+def requires(requirements):
+    def wrap(func):
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            diff = set(requirements) - set(args[0].store.features)
+            if diff:
+                raise WrongStoreType(features=requirements)
+            else:
+                return func(*args, **kwargs)
+        return inner
+    return wrap
+
+
+@requires(['sql'])
+def get_epg_by_host_names(context, host_names):
+    session = context.store.db_session
+    with session.begin(subtransactions=True):
+        result = []
+        for epg_db in session.query(models.EndpointGroup).join(
+                models.EndpointGroup.static_paths).filter(
+                models.EndpointGroupStaticPath.host.in_(host_names)).all():
+            result.append(context.store.make_resource(resource.EndpointGroup,
+                                                      epg_db))
+    return result


### PR DESCRIPTION
In some cases we might want to use more complicated queries than
the ones allowed by the aim manager for improved performance.
For such cases, introduce a sql optimizer module which exposes
some specific search methods and tries to resolve them with
the least number of sqlalchemy queries possible.