### PR TITLE
Update DB objects when actually needed.

### DIFF
--- a/aim/agent/aid/service.py
+++ b/aim/agent/aid/service.py
@@ -97,7 +97,7 @@ class AID(object):
                                     description=AGENT_DESCRIPTION,
                                     version=AGENT_VERSION)
         # Register agent
-        self._send_heartbeat(aim_ctx)
+        self.agent = self.manager.create(aim_ctx, self.agent, overwrite=True)
         # Report procedure should happen asynchronously
         self.polling_interval = self.conf_manager.get_option_and_subscribe(
             self._change_polling_interval, 'agent_polling_interval',
@@ -211,8 +211,7 @@ class AID(object):
 
     def _send_heartbeat(self, aim_ctx):
         LOG.info("Sending Heartbeat for agent %s" % self.agent_id)
-        self.agent = self.manager.create(aim_ctx, self.agent,
-                                         overwrite=True)
+        self.agent = self.manager.update(aim_ctx, self.agent)
 
     def _calculate_tenants(self, aim_ctx):
         # REVISIT(ivar): should we lock the Agent table?

--- a/aim/aim_lib/nat_strategy.py
+++ b/aim/aim_lib/nat_strategy.py
@@ -594,10 +594,10 @@ class NoNatStrategy(NatStrategyMixin):
             self._set_bd_l3out(ctx, l3out, vrf, exclude_bd=nat_bd)
 
             contract = self._get_nat_contract(ctx, l3out)
-            prov = set(external_network.provided_contract_names +
-                       [contract.name])
-            cons = set(external_network.consumed_contract_names +
-                       [contract.name])
+            prov = list(set(external_network.provided_contract_names +
+                            [contract.name]))
+            cons = list(set(external_network.consumed_contract_names +
+                            [contract.name]))
             self.mgr.update(ctx, external_network,
                             provided_contract_names=prov,
                             consumed_contract_names=cons)

--- a/aim/api/service_graph.py
+++ b/aim/api/service_graph.py
@@ -154,6 +154,7 @@ class ServiceGraph(resource.AciResourceBase):
                          ('device_cluster_tenant_name', t.name))),
         ('monitored', t.bool))
 
+    sorted_attributes = ['linear_chain_nodes']
     _aci_mo_name = 'vnsAbsGraph'
     _tree_parent = resource.Tenant
 

--- a/aim/db/agent_model.py
+++ b/aim/db/agent_model.py
@@ -62,14 +62,13 @@ class Agent(model_base.Base, model_base.HasId, model_base.AttributeMixin):
                 keep.append(curr)
                 trees.remove(curr.tree_root_rn)
         self.hash_trees = keep
-        with session.begin(subtransactions=True):
-            for tree in trees:
-                self.tree_exists(session, tree)
-                # Check whether the current object already has an ID, use
-                # the one passed in the getter otherwise.
-                db_obj = tree_model.AgentToHashTreeAssociation(
-                    agent_id=self.id or kwargs.get('id'), tree_root_rn=tree)
-                self.hash_trees.append(db_obj)
+        for tree in trees:
+            self.tree_exists(session, tree)
+            # Check whether the current object already has an ID, use
+            # the one passed in the getter otherwise.
+            db_obj = tree_model.AgentToHashTreeAssociation(
+                agent_id=self.id or kwargs.get('id'), tree_root_rn=tree)
+            self.hash_trees.append(db_obj)
 
     def get_hash_trees(self, session):
         # Only return the trees' identifier

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -309,14 +309,14 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # Create 2 tenants by initiating their objects
         tn1 = resource.Tenant(name=tenant_name1)
         tn2 = resource.Tenant(name=tenant_name2)
-        self.aim_manager.create(self.ctx, tn1)
+        tn = self.aim_manager.create(self.ctx, tn1)
         self.aim_manager.create(self.ctx, tn2)
 
         bd1_tn1 = resource.BridgeDomain(tenant_name=tenant_name1, name='bd1',
                                         vrf_name='vrf1')
         bd1_tn2 = resource.BridgeDomain(tenant_name=tenant_name2, name='bd1',
                                         vrf_name='vrf2', display_name='nice')
-        self.aim_manager.create(self.ctx, bd1_tn2)
+        bd = self.aim_manager.create(self.ctx, bd1_tn2)
         self.aim_manager.create(self.ctx, bd1_tn1)
         self.aim_manager.get_status(self.ctx, bd1_tn1)
         self.aim_manager.get_status(self.ctx, bd1_tn2)
@@ -357,6 +357,10 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
 
         # Now, the two trees are in sync
         agent._reconciliation_cycle(self.ctx)
+        tn_after = self.aim_manager.get(self.ctx, tn)
+        bd_after = self.aim_manager.get(self.ctx, bd)
+        self.assertEqual(tn_after.epoch, tn.epoch)
+        self.assertEqual(bd_after.epoch, bd.epoch)
         self._assert_universe_sync(agent.desired_universe,
                                    agent.current_universe,
                                    tenants=[tn1.root, tn2.root])


### PR DESCRIPTION
With the introduction of the object versioning, only
update/overwrite objects when there are actual changes to avoid
unwanted stale data errors.