### PR TITLE
Modify host column size

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/1b58ffa871bb_add_host_column.py
+++ b/aim/db/migration/alembic_migrations/versions/1b58ffa871bb_add_host_column.py
@@ -36,19 +36,19 @@ from aim.db.migration.data_migration import add_host_column
 def upgrade():
     op.add_column(
         'aim_endpoint_group_static_paths',
-        sa.Column('host', sa.String(1024), nullable=True, index=True)
+        sa.Column('host', sa.String(512), nullable=True, index=True)
     )
     op.add_column(
         'aim_concrete_device_ifs',
-        sa.Column('host', sa.String(1024), nullable=True, index=True)
+        sa.Column('host', sa.String(512), nullable=True, index=True)
     )
     op.add_column(
         'aim_device_cluster_devices',
-        sa.Column('host', sa.String(1024), nullable=True, index=True)
+        sa.Column('host', sa.String(512), nullable=True, index=True)
     )
     op.add_column(
         'aim_l3out_interfaces',
-        sa.Column('host', sa.String(1024), nullable=True, index=True)
+        sa.Column('host', sa.String(512), nullable=True, index=True)
     )
     session = sa.orm.Session(bind=op.get_bind(), autocommit=True)
     add_host_column.migrate(session)

--- a/aim/db/migration/alembic_migrations/versions/fabed2911290_modify_host_column_size.py
+++ b/aim/db/migration/alembic_migrations/versions/fabed2911290_modify_host_column_size.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2018 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Modify host column size
+
+Revision ID: fabed2911290
+Revises: 2c47aab91fff
+Create Date: 2018-04-23 15:30:10.357536
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fabed2911290'
+down_revision = '2c47aab91fff'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+TABLES = ('aim_endpoint_group_static_paths',
+          'aim_concrete_device_ifs',
+          'aim_device_cluster_devices',
+          'aim_l3out_interfaces')
+
+
+def upgrade():
+    for table in TABLES:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.alter_column(
+                'host', existing_type=sa.String(length=1024),
+                type_=sa.String(512))
+
+
+def downgrade():
+    pass

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -241,7 +241,7 @@ class EndpointGroupStaticPath(model_base.Base):
     # Use VARCHAR with ASCII encoding to work-around MySQL limitations
     # on the length of primary keys
     path = sa.Column(VARCHAR(512, charset='latin1'), primary_key=True)
-    host = sa.Column(sa.String(1024), nullable=True, index=True)
+    host = sa.Column(sa.String(512), nullable=True, index=True)
     encap = sa.Column(sa.String(24))
 
 
@@ -685,7 +685,7 @@ class L3OutInterface(model_base.Base, model_base.HasAimId,
     interface_path = sa.Column(VARCHAR(512, charset='latin1'), nullable=False)
     encap = sa.Column(sa.String(24), nullable=False)
     type = sa.Column(sa.String(16), nullable=False)
-    host = sa.Column(sa.String(1024), nullable=True, index=True)
+    host = sa.Column(sa.String(512), nullable=True, index=True)
     primary_addr_a = sa.Column(sa.String(64), nullable=False)
     primary_addr_b = sa.Column(sa.String(64))
     secondary_addr_a_list = orm.relationship(L3OutInterfaceSecondaryIpA,

--- a/aim/db/service_graph_model.py
+++ b/aim/db/service_graph_model.py
@@ -30,7 +30,7 @@ class DeviceClusterDevice(model_base.Base):
                           primary_key=True)
     name = model_base.name_column(primary_key=True)
     path = sa.Column(sa.String(512))
-    host = sa.Column(sa.String(1024), nullable=True, index=True)
+    host = sa.Column(sa.String(512), nullable=True, index=True)
 
 
 class DeviceCluster(model_base.Base, model_base.HasAimId,
@@ -161,7 +161,7 @@ class ConcreteDeviceInterface(model_base.Base, model_base.HasAimId,
     device_cluster_name = model_base.name_column(nullable=False)
     device_name = model_base.name_column(nullable=False)
     path = sa.Column(sa.String(512))
-    host = sa.Column(sa.String(1024), nullable=True, index=True)
+    host = sa.Column(sa.String(512), nullable=True, index=True)
 
 
 class ServiceGraphConnectionConnector(model_base.Base):


### PR DESCRIPTION
Some engines have a limit for index keys of 767 characters.
Resize host columns accordingly.