### PR TITLE
Set confirm_deleted_rows to False

### DIFF
--- a/aim/db/model_base.py
+++ b/aim/db/model_base.py
@@ -104,7 +104,8 @@ class AttributeMixin(object):
 
     __mapper_args__ = {
         "version_id_col": epoch,
-        "version_id_generator": False
+        "version_id_generator": False,
+        "confirm_deleted_rows": False,
     }
 
     def bump_epoch(self):

--- a/aim/db/tree_model.py
+++ b/aim/db/tree_model.py
@@ -77,6 +77,7 @@ class ActionLog(model_base.Base, model_base.AttributeMixin):
     # to be bumped at the DB level.
     __mapper_args__ = {
         "version_id_col": model_base.AttributeMixin.epoch,
+        "confirm_deleted_rows": False,
     }
 
     id = sa.Column(sa.BigInteger().with_variant(sa.Integer(), 'sqlite'),

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -540,6 +540,20 @@ class TestResourceOpsBase(object):
                 self.mgr)._retrieve_class_root_type(self.resource_class)
             self.assertEqual(self.resource_root_type, klass_type)
 
+    def test_delete_warning(self):
+        creation_attributes = {}
+        creation_attributes.update(self.test_required_attributes),
+        creation_attributes.update(self.test_identity_attributes)
+        res = self.resource_class(**creation_attributes)
+        self.mgr.create(self.ctx, res)
+        store2 = api.get_store()
+        store2.db_session.begin()
+        db_type = store2.resource_to_db_type(res.__class__)
+        db_obj = store2.query(db_type, res.__class__)[0]
+        self.mgr.delete(self.ctx, res)
+        store2.delete(db_obj)
+        store2.db_session.commit()
+
     @base.requires(['sql'])
     def test_race(self):
         def _test_race(res):


### PR DESCRIPTION
We typically don't care about deletion errors: if we try to delete
something that has already been deleted, then the final state is
already what we desire.
However, sqlalchemy rises exceptions whenever a race condition occurs
while trying to delete a DB object. By setting confirm_deleted_rows
to False in the mapping args, we prevent this exception from happening,
thus avoiding one set of possible retriable errors.