### PR TITLE
Refactor AIM context usage in AID

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -314,7 +314,7 @@ class AciUniverse(base.HashTreeStoredUniverse):
         global serving_tenants
         return serving_tenants
 
-    def serve(self, tenants):
+    def serve(self, context, tenants):
         # Verify differences
         global serving_tenants
         try:
@@ -379,7 +379,7 @@ class AciUniverse(base.HashTreeStoredUniverse):
         context = aim_ctx.AimContext(store=store)
         self.creation_failed(context, aim_object, reason=reason, error=error)
 
-    def observe(self):
+    def observe(self, context):
         # Copy state accumulated so far
         global serving_tenants
         new_state = {}
@@ -389,7 +389,7 @@ class AciUniverse(base.HashTreeStoredUniverse):
                 new_state[tenant] = self._get_state_copy(tenant)
         self._state = new_state
 
-    def reset(self, tenants):
+    def reset(self, context, tenants):
         # Reset can only be called during reconciliation. serving_tenants
         # can't be modified meanwhile
         global serving_tenants
@@ -402,7 +402,7 @@ class AciUniverse(base.HashTreeStoredUniverse):
                     LOG.error(traceback.format_exc())
                     LOG.error('Failed to reset tenant %s' % root)
 
-    def push_resources(self, resources):
+    def push_resources(self, context, resources):
         # Organize by tenant, and push into APIC
         global serving_tenants
         by_tenant = {}
@@ -483,7 +483,7 @@ class AciUniverse(base.HashTreeStoredUniverse):
             sign_hash=apic_config.get_option(
                 'signature_hash_type', group='apic'))
 
-    def update_status_objects(self, my_state, raw_diff, skip_keys):
+    def update_status_objects(self, context, my_state, raw_diff, skip_keys):
         pass
 
     def _action_items_to_aim_resources(self, actions, action):

--- a/aim/common/utils.py
+++ b/aim/common/utils.py
@@ -158,6 +158,7 @@ class StopLoop(Exception):
 
 def retry_loop(max_wait, max_retries, name, fail=False, return_=False):
     def wrap(func):
+        @functools.wraps(func)
         def inner(*args, **kwargs):
             recovery_retries = None
             while True:
@@ -294,6 +295,7 @@ def get_rlock(lock_name, blocking=True):
 
 def rlock(lock_name):
     def wrap(func):
+        @functools.wraps(func)
         def inner(*args, **kwargs):
             # setdefault is atomic
             lock = generate_rlock(lock_name)


### PR DESCRIPTION
Context should be re-generated at each reconciliation cycle, and
passed down to all universes on a per-operation basis instead of
having each universe instancing their own context.

This will guarantee that the context will be re-generated upon
error.