### PR TITLE
Fix for critical DB error with postgres backend

### DIFF
--- a/aim/db/tree_model.py
+++ b/aim/db/tree_model.py
@@ -46,7 +46,7 @@ class Tree(model_base.Base, model_base.AttributeMixin):
     agents = orm.relationship(AgentToHashTreeAssociation,
                               backref='hash_trees',
                               cascade='all, delete-orphan',
-                              lazy="joined")
+                              lazy="subquery")
 
 
 class TypeTreeBase(object):


### PR DESCRIPTION
Fixes: https://github.com/noironetworks/aci-integration-module/issues/231

The commit updates the tree_model in migration to use lazy_load (http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#lazy-loading) which emits a SELECT statement instead of the Joined Eager Loading (http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#joined-eager-loading ) which emits a LEFT OUTER JOIN by default on the SELECT statement causing the postgres backend to produce the error. 