### PR TITLE
Fix for duplicate uniq_agents

### DIFF
--- a/aim/db/agent_model.py
+++ b/aim/db/agent_model.py
@@ -32,7 +32,7 @@ class Agent(model_base.Base, model_base.HasId, model_base.AttributeMixin):
 
     __table_args__ = (
         sa.UniqueConstraint('agent_type', 'host',
-                            name='uniq_agents0agent_type0host'),
+                            name='aim_agents_uniq_agents0agent_type0host'),
         model_base.Base.__table_args__
     )
 

--- a/aim/db/migration/alembic_migrations/versions/accfe645090a_agent_resource.py
+++ b/aim/db/migration/alembic_migrations/versions/accfe645090a_agent_resource.py
@@ -48,7 +48,7 @@ def upgrade():
         sa.Column('version', sa.String(10)),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('agent_type', 'host',
-                            name='uniq_agents0agent_type0host'))
+                            name='aim_agents_uniq_agents0agent_type0host'))
 
     op.create_table(
         'aim_agent_to_tree_associations',


### PR DESCRIPTION
The names uniq_agents0agent_type0host conflicts with the unique values created by neutron db schema. This conflict throws errors due to the uniqueness constraint. This commit fixes the unique name constraint with a separate name for aim_agents.