### PR TITLE
Reduce the children delete requests to APIC

### DIFF
--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -231,6 +231,7 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         result = self.universe.get_resources(keys)
         self.assertEqual(sorted(objs), sorted(result))
 
+    # TODO(kentwu): need to enable this test case
     @base.requires(['skip'])
     def test_get_resources_for_delete(self):
         objs = [


### PR DESCRIPTION
1. For ACI universe, if the parent object was already deleted in the
desired config tree then we don't even put the children deletion into
the queue.
2. Use the DN Manager to compose the parent DN instead. This is the
standard way instead of searching for the next '/'.