### PR TITLE
Cap oslo.messaging below version 9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ kubernetes
 oslo.concurrency
 oslo.config
 oslo.db
-oslo.messaging
+oslo.messaging<9.0
 oslo.log
 oslo.utils
 pbr>=1.6,<2.0


### PR DESCRIPTION
This is a temporary workaround for an issue introduced by version 9.0 of oslo.messaging. A real fix would be to avoid using deprecated API.