### PR TITLE
Make status DN DB migration atomic

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/bcdef2211410_status_add_dn.py
+++ b/aim/db/migration/alembic_migrations/versions/bcdef2211410_status_add_dn.py
@@ -31,17 +31,19 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.mysql import VARCHAR
 
+from aim.db import api
 from aim.db.migration.data_migration import status_add_dn
 
 
 def upgrade():
 
-    op.add_column(
-        'aim_statuses',
-        sa.Column('resource_dn', VARCHAR(512, charset='latin1'),
-                  nullable=False, server_default=''))
-    session = sa.orm.Session(bind=op.get_bind(), autocommit=True)
-    status_add_dn.migrate(session)
+    session = api.get_session(expire_on_commit=True)
+    with session.begin(subtransactions=True):
+        op.add_column(
+            'aim_statuses',
+            sa.Column('resource_dn', VARCHAR(512, charset='latin1'),
+                      nullable=False, server_default=''))
+        status_add_dn.migrate(session)
 
 
 def downgrade():


### PR DESCRIPTION
This is tracked in https://github.com/noironetworks/support/issues/799.
The DB migration can fail, leaving this DB migration in a half-committed
state, and therefore not idempotent. This adds everything to a single
transaction, ensuring that it can be re-run if it fails.