### PR TITLE
Fix data migration

### DIFF
--- a/aim/db/migration/data_migration/status_add_dn.py
+++ b/aim/db/migration/data_migration/status_add_dn.py
@@ -56,6 +56,10 @@ def migrate(session):
             res_table, res_class = get_resource_class(st.resource_type)
             db_res = session.query(res_table).filter_by(
                 aim_id=st.resource_id).first()
-            res = store.make_resource(res_class, db_res)
-            session.execute(update(Status).where(
-                Status.c.id == st.id).values(resource_dn=res.dn))
+            try:
+                res = store.make_resource(res_class, db_res)
+                session.execute(update(Status).where(
+                    Status.c.id == st.id).values(resource_dn=res.dn))
+            except Exception:
+                # Silently ignore
+                pass


### PR DESCRIPTION
The data migration code for the status DN would cause problems
if it tried to migrate information in a status object for a
tenant that no longer exists in AIM DB. Silently ignore these
cases.