### PR TITLE
Don't delete the tenant prematurely

### DIFF
--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -229,7 +229,8 @@ class AciTenantManager(utils.AIMThread):
         with utils.get_rlock(lcon.ACI_TREE_LOCK_NAME_PREFIX +
                              self.tenant_name):
             return structured_tree.StructuredHashTree.from_string(
-                str(self._state), root_key=self._state.root_key)
+                str(self._state), root_key=self._state.root_key,
+                has_populated=self._state.has_populated)
 
     def get_operational_state_copy(self):
         with utils.get_rlock(lcon.ACI_TREE_LOCK_NAME_PREFIX +

--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -146,12 +146,13 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
 
     def finalize_deletion_candidates(self, context, other_universe,
                                      delete_candidates):
-        super(AimDbUniverse, self).finalize_deletion_candidates(
-            context, other_universe, delete_candidates)
+        self._pop_up_sync_log(delete_candidates)
         other_state = other_universe.state
         for tenant in list(delete_candidates):
             # Remove tenants that have been emptied.
-            if tenant not in other_state or not other_state[tenant].root:
+            # This means the tenant has been created then deleted
+            if (tenant in other_state and not other_state[tenant].root and
+                    other_state[tenant].has_populated is True):
                 pass
             else:
                 delete_candidates.discard(tenant)
@@ -345,8 +346,7 @@ class AimDbOperationalUniverse(AimDbUniverse):
 
     def finalize_deletion_candidates(self, context, other_universe,
                                      delete_candidates):
-        super(AimDbOperationalUniverse, self).finalize_deletion_candidates(
-            context, other_universe, delete_candidates)
+        self._pop_up_sync_log(delete_candidates)
         my_state = self.state
         for tenant in list(delete_candidates):
             # Remove tenants that have been emptied.
@@ -402,8 +402,7 @@ class AimDbMonitoredUniverse(AimDbUniverse):
 
     def finalize_deletion_candidates(self, context, other_universe,
                                      delete_candidates):
-        super(AimDbMonitoredUniverse, self).finalize_deletion_candidates(
-            context, other_universe, delete_candidates)
+        self._pop_up_sync_log(delete_candidates)
         my_state = self.state
         for tenant in list(delete_candidates):
             # Remove tenants that have been emptied.

--- a/aim/agent/aid/universes/base_universe.py
+++ b/aim/agent/aid/universes/base_universe.py
@@ -338,11 +338,14 @@ class HashTreeStoredUniverse(AimUniverse):
                                  delete_candidates, vetoes):
         pass
 
-    def finalize_deletion_candidates(self, context, other_universe,
-                                     delete_candidates):
+    def _pop_up_sync_log(self, delete_candidates):
         for root in delete_candidates:
             with utils.get_rlock(lcon.SYNC_LOG_LOCK + root):
                 self._sync_log.pop(root, None)
+
+    def finalize_deletion_candidates(self, context, other_universe,
+                                     delete_candidates):
+        self._pop_up_sync_log(delete_candidates)
 
     def _reconcile(self, context, other_universe):
         # "self" is always the current state, "other" the desired

--- a/aim/common/hashtree/structured_tree.py
+++ b/aim/common/hashtree/structured_tree.py
@@ -178,9 +178,9 @@ class StructuredHashTree(base.ComparableCollection):
     tree.pop(('tn-tenant', 'bd-bridge3'))
     """
 
-    __slots__ = ['root', 'root_key']
+    __slots__ = ['root', 'root_key', 'has_populated']
 
-    def __init__(self, root=None, root_key=None):
+    def __init__(self, root=None, root_key=None, has_populated=False):
         """Initialize a Structured Hash Tree.
 
         Initial data can be passed to initialize the tree
@@ -191,6 +191,7 @@ class StructuredHashTree(base.ComparableCollection):
         if self.root:
             # Ignore the value passed in the constructor
             self.root_key = self.root.key
+        self.has_populated = has_populated
 
     @property
     def root_full_hash(self):
@@ -202,10 +203,12 @@ class StructuredHashTree(base.ComparableCollection):
             return None
 
     @staticmethod
-    def from_string(string, root_key=None):
+    def from_string(string, root_key=None, has_populated=False):
         to_dict = utils.json_loads(string)
-        return (StructuredHashTree(StructuredHashTree._build_tree(to_dict)) if
-                to_dict else StructuredHashTree(root_key=root_key))
+        return (StructuredHashTree(StructuredHashTree._build_tree(to_dict),
+                                   has_populated=has_populated) if
+                to_dict else StructuredHashTree(root_key=root_key,
+                                                has_populated=has_populated))
 
     @staticmethod
     def _build_tree(root_dict):
@@ -233,6 +236,7 @@ class StructuredHashTree(base.ComparableCollection):
             self.root = StructuredTreeNode(
                 (key[0],), self._hash_attributes(key=(key[0],), _dummy=True))
             self.root_key = self.root.key
+            self.has_populated = True
         else:
             # With the first element of the key, verify that this is not an
             # attempt of creating a hydra (tree with multiple roots)

--- a/aim/tests/unit/test_structured_hash_tree.py
+++ b/aim/tests/unit/test_structured_hash_tree.py
@@ -212,10 +212,12 @@ class TestStructuredHashTree(base.BaseTestCase):
     def test_initialize(self):
         data = tree.StructuredHashTree()
         self.assertIsNone(data.root)
+        self.assertEqual(data.has_populated, False)
         data = tree.StructuredHashTree().include(
             [{'key': ('keyA', 'keyB')}, {'key': ('keyA', 'keyC')}])
         self.assertIsNotNone(data.root)
         self.assertEqual(('keyA',), data.root.key)
+        self.assertEqual(data.has_populated, True)
 
     def test_str(self):
         data = tree.StructuredHashTree()
@@ -227,6 +229,7 @@ class TestStructuredHashTree(base.BaseTestCase):
         # Add on empty root
         data = tree.StructuredHashTree()
         data.add(('keyA', 'keyB', 'keyC'), **{})
+        self.assertEqual(data.has_populated, True)
         self.assertEqual(('keyA',), data.root.key)
         full_hash_gramp1 = data.root.full_hash
         self.assertEqual(1, len(data.root.get_children()))
@@ -275,6 +278,7 @@ class TestStructuredHashTree(base.BaseTestCase):
         retured = data.add(None)
         # Nothing happened
         self.assertEqual(data, retured)
+        self.assertEqual(data.has_populated, False)
 
     def test_add_multiple_heads(self):
         data = tree.StructuredHashTree().add(('keyA', 'keyB'))
@@ -372,6 +376,7 @@ class TestStructuredHashTree(base.BaseTestCase):
              {'key': ('keyA1', 'keyC', 'keyD')}])
         # Verify everything is rolled back
         self.assertEqual(data, data_copy)
+        self.assertEqual(data_copy.has_populated, True)
 
     def test_pop(self):
         data = tree.StructuredHashTree()
@@ -549,10 +554,12 @@ class TestStructuredHashTree(base.BaseTestCase):
             [{'key': ('keyA', 'keyB'), '_metadata': {'a': 20}},
              {'key': ('keyA', 'keyC'), '_metadata': {'b': False}},
              {'key': ('keyA', 'keyC', 'keyD')}])
-        data2 = tree.StructuredHashTree.from_string(str(data))
+        data2 = tree.StructuredHashTree.from_string(
+            str(data), has_populated=data.has_populated)
         self.assertTrue(data is not data2)
         self.assertEqual(data, data2)
         self.assertTrue(self._tree_deep_check(data.root, data2.root))
+        self.assertEqual(data2.has_populated, True)
 
     def test_list_keys(self):
         data = tree.StructuredHashTree().include(


### PR DESCRIPTION
Make sure aci_universe has populated the tenant in its tree before
aim_universe can go ahead to remove it. This is to prevent a situation
especially during tempest tests that a tenant is being created and
deleted rapidly. What happens there is that before the tenant thread
can pick up the tenant creation event from APIC then update the
aci_universe tree accordingly, that tenant is already deleted in AIM.
Then the sanity test in aim_universe finalize_deletion_candidates()
will still pass because at that point, both aim and aci universe don't
have that tenant in its tree.