### PR TITLE
Remove Observer and Sync Log Locking

### DIFF
--- a/aim/agent/aid/service.py
+++ b/aim/agent/aid/service.py
@@ -23,7 +23,6 @@ import semantic_version
 from aim.agent.aid import event_handler
 from aim.agent.aid.universes.aci import aci_universe
 from aim.agent.aid.universes import aim_universe
-from aim.agent.aid.universes import constants as lcon
 from aim.agent.aid.universes.k8s import k8s_watcher
 from aim import aim_manager
 from aim.api import resource
@@ -169,10 +168,9 @@ class AID(object):
         # time for events to happen
 
         # Observe the two universes to fix their current state
-        with utils.get_rlock(lcon.AID_OBSERVER_LOCK):
-            for pair in self.multiverse:
-                pair[DESIRED].observe(aim_ctx)
-                pair[CURRENT].observe(aim_ctx)
+        for pair in self.multiverse:
+            pair[DESIRED].observe(aim_ctx)
+            pair[CURRENT].observe(aim_ctx)
 
         delete_candidates = set()
         vetoes = set()


### PR DESCRIPTION
Commit caf2d39df23707ca20cb547e0aa1f6b3c596e added a lock for
error handling, which was modified later to its current state
by commit 6256a9b3d3ac96fe0e4f8f12d32a0374c7c52ca5. The only
context manipulating this data structure is the main AID loop,
so locking shouldn't be needed.

Similarly, commit c0ccb3f1900ddb1d519da07783e4ec5f87f01e27 added
locking for calls to observe. Since the main AID loop is the
only context doing this, locking should not be needed.

This patch removes both of the above locks.

There are also cases where the same lock is obtained twice
in the same context. Commit c0ccb3f1900ddb1d519da07783e4ec5f87f01e27
added locking when getting the configured, operational, and monitored
hash trees from the AciTenantManager objects. However, these calls are
only ever made from the main AID loop context (_get_state_copy method),
which already takes the per-tenant tree lock at the beginning of the
observe call, which is also where the _get_state_copy call is made.
The other example is _event_to_tree, which gets the same per-tenant-
tree lock. The only caller of this is _event_loop, which already has
this lock when it calls _event_to_tree.

This patch also removes those duplicate uses.