### PR TITLE
Fix query_statuses to return empty list if no aim res provided

### DIFF
--- a/aim/aim_store.py
+++ b/aim/aim_store.py
@@ -352,6 +352,8 @@ class SqlAlchemyStore(AimStore):
         return query
 
     def query_statuses(self, resources):
+        if not resources:
+            return []
         db_ids_by_type = {}
         for res in resources:
             db_ids_by_type.setdefault(self.db_model_map[type(res)], []).append(

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -173,6 +173,11 @@ class TestAimManager(base.TestAimDBBase):
             set((x for x in statuses if x.resource_root == 'tn-t1')),
             set(statusest1))
 
+    def test_multiple_statuses_with_no_resource(self):
+        expected_statuses = []
+        statuses = self.mgr.get_statuses(self.ctx, [])
+        self.assertEqual(expected_statuses, statuses)
+
 
 class TestResourceOpsBase(object):
     test_dn = None


### PR DESCRIPTION
Add a check to return back an empty list if no aim resources
are provided to get corresponding status objects.