### PR TITLE
Override default for use_stderr to False

### DIFF
--- a/etc/aim/aim.conf
+++ b/etc/aim/aim.conf
@@ -3,6 +3,7 @@ debug=True
 rpc_backend=rabbit
 control_exchange=neutron
 default_log_levels=neutron.context=ERROR
+use_stderr=False
 
 [oslo_messaging_rabbit]
 #rabbit_host=<rabbit-mq-host>


### PR DESCRIPTION
In older releases of oslo_log, the use_stderr cfg_opt has a default
of True. This results in logs getting replicated to /var/log/messages
in addition to the targetted log file as seen in newton deployments.
Being unnecessary duplication the community has fixed this in later
releases, we set it to False in the aim.conf template for installers
to pick up.