### PR TITLE
Fix Python3 support for Aci-Integration-Module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py27
-  - TOX_ENV=pep8
+
+matrix:
+  include:
+    - python: 2.7
+      env:
+        - TOX_ENV=py27
+    - python: 2.7
+      env:
+        - TOX_ENV=pep8
+    - python: 3.6
+      env:
+        - TOX_ENV=py36
+    - python: 3.6
+      env:
+        - TOX_ENV=pep8
 install:
   - pip install tox
+
 script:
   - tox -e $TOX_ENV

--- a/aim/agent/aid/event_handler.py
+++ b/aim/agent/aid/event_handler.py
@@ -15,8 +15,8 @@
 
 import abc
 import os
-import Queue as queue
 import six
+from six.moves import queue
 import socket
 import time
 import traceback
@@ -139,6 +139,7 @@ class EventHandler(EventHandlerBase):
 
     def _recv_loop(self):
         event = self.sock.recv(PAYLOAD_MAX_LEN)
+        event = event.decode('utf-8')
         LOG.debug("Received event %s" % event)
         if event.lower() in EVENTS:
             self._put_event(event)
@@ -197,10 +198,10 @@ class EventSender(SenderBase):
     def _send(self, event):
         LOG.debug("Sending %s event" % event)
         try:
-            self.sock.send(event)
+            self.sock.send(event.encode('utf-8'))
         except Exception as e:
             LOG.debug(traceback.format_exc())
             LOG.error("An error as occurred in the event sender "
-                      "thread: %s" % e.message)
+                      "thread: %s" % str(e))
             self.sock.close()
             self.initialize(self.conf_manager)

--- a/aim/agent/aid/event_services/rpc.py
+++ b/aim/agent/aid/event_services/rpc.py
@@ -47,7 +47,7 @@ class AIDEventRpcApi(object):
                 oslo_messaging.InvalidTransportURL) as ex:
             LOG.debug(traceback.format_exc())
             LOG.debug("Couldn't initialize RPC transport, this API will be a "
-                      "noop: %s" % ex.message)
+                      "noop: %s" % str(ex))
             self.client = None
 
     def serve(self, context, server=None):

--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -361,7 +361,7 @@ class WebSocketContext(object):
                                     "Will retry %s more times: %s" %
                                     (name,
                                      max_retries - name_to_retry[name].get(),
-                                     e.message))
+                                     str(e)))
                                 continue
                     elif thd:
                         LOG.debug("Thread %s is in good shape" % name)
@@ -395,7 +395,7 @@ class WebSocketContext(object):
                 # for testing purposes
                 flag['monitor_runs'] -= 1
         except Exception as e:
-            msg = ("Unknown error in thread monitor: %s" % e.message)
+            msg = ("Unknown error in thread monitor: %s" % str(e))
             LOG.error(msg)
             utils.perform_harakiri(LOG, msg)
 
@@ -475,7 +475,7 @@ class AciUniverse(base.HashTreeStoredUniverse):
                 except Exception as e:
                     LOG.debug(traceback.format_exc())
                     LOG.error('Killing manager failed for tenant %s: %s' %
-                              (removed, e.message))
+                              (removed, str(e)))
                     continue
             for added in tenants:
                 if added in serving_tenant_copy:
@@ -551,14 +551,14 @@ class AciUniverse(base.HashTreeStoredUniverse):
         # Organize by tenant, and push into APIC
         global serving_tenants
         by_tenant = {}
-        for method, objects in resources.iteritems():
+        for method, objects in resources.items():
             for data in objects:
                 tenant_name = self._retrieve_tenant_rn(data)
                 if tenant_name:
                     by_tenant.setdefault(tenant_name, {}).setdefault(
                         method, []).append(data)
 
-        for tenant, conf in by_tenant.iteritems():
+        for tenant, conf in by_tenant.items():
             try:
                 serving_tenants[tenant]
             except KeyError:
@@ -570,9 +570,9 @@ class AciUniverse(base.HashTreeStoredUniverse):
 
     def _retrieve_tenant_rn(self, data):
         if isinstance(data, dict):
-            if data.keys()[0] == 'tagInst':
+            if list(data.keys())[0] == 'tagInst':
                 # Retrieve tag parent
-                dn = data.values()[0]['attributes']['dn']
+                dn = list(data.values())[0]['attributes']['dn']
                 decomposed = apic_client.DNManager().aci_decompose_dn_guess(
                     dn, 'tagInst')
                 parent_type = decomposed[1][-2][0]
@@ -593,17 +593,17 @@ class AciUniverse(base.HashTreeStoredUniverse):
             if node and not node.dummy:
                 # Monitored state transition -> Delete the TAG instead
                 LOG.debug("Deleting tag for transitioning object %s",
-                          aci_object.values()[0]['attributes']['dn'])
+                          list(aci_object.values())[0]['attributes']['dn'])
                 aci_type = 'tagInst'
-                dn = aci_object.values()[0]['attributes'][
+                dn = list(aci_object.values())[0]['attributes'][
                     'dn'] + '/tag-' + self.aim_system_id
                 result.append({aci_type: {'attributes': {'dn': dn}}})
             else:
                 # If the parent object was already deleted in the config
                 # desired tree then we don't have to send this child deletion
                 # to APIC
-                dn = aci_object.values()[0]['attributes']['dn']
-                res_type = aci_object.keys()[0]
+                dn = list(aci_object.values())[0]['attributes']['dn']
+                res_type = list(aci_object.keys())[0]
                 dn_mgr = apic_client.DNManager()
                 mo, rns = dn_mgr.aci_decompose_dn_guess(dn, res_type)
                 if len(rns) > 1:
@@ -672,7 +672,7 @@ class AciUniverse(base.HashTreeStoredUniverse):
         else:
             # it's in ACI format
             return tree_manager.AimHashTreeMaker._extract_root_from_dn(
-                res.values()[0]['attributes']['dn'])
+                list(res.values())[0]['attributes']['dn'])
 
 
 class AciOperationalUniverse(AciUniverse):
@@ -693,9 +693,9 @@ class AciOperationalUniverse(AciUniverse):
             if node and not node.dummy:
                 # Monitored state transition -> Delete the TAG instead
                 LOG.debug("Deleting tag for transitioning object %s",
-                          aci_object.values()[0]['attributes']['dn'])
+                          list(aci_object.values())[0]['attributes']['dn'])
                 aci_type = 'tagInst'
-                dn = aci_object.values()[0]['attributes'][
+                dn = list(aci_object.values())[0]['attributes'][
                     'dn'] + '/tag-' + self.aim_system_id
                 result.append({aci_type: {'attributes': {'dn': dn}}})
             else:

--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -862,7 +862,7 @@ resource_map.update(service_graph.resource_map)
 
 # Build the reverse map for reverse translation
 reverse_resource_map = {}
-for apic_type, rule_list in resource_map.iteritems():
+for apic_type, rule_list in resource_map.items():
     for rules in rule_list:
         klass = rules['resource']
         mapped_klass = reverse_resource_map.setdefault(klass, [])
@@ -954,19 +954,19 @@ class AciToAimModelConverter(BaseConverter):
         result = []
         for object in aci_objects:
             try:
-                if object.keys()[0] not in resource_map:
+                if list(object.keys())[0] not in resource_map:
                     # Ignore unmanaged object
                     continue
-                resource = object[object.keys()[0]]['attributes']
+                resource = object[list(object.keys())[0]]['attributes']
                 # Change nameAlias to allow automatic conversion
                 if 'nameAlias' in resource:
                     resource['displayName'] = resource['nameAlias']
                     del resource['nameAlias']
-                for helper in resource_map[object.keys()[0]]:
+                for helper in resource_map[list(object.keys())[0]]:
                     # Use the custom converter, fallback to the default one
                     converted = (
                         helper.get('converter') or self._default_converter)(
-                        resource, object.keys()[0], helper,
+                        resource, list(object.keys())[0], helper,
                         ['dn'], helper['resource'].identity_attributes,
                         to_aim=True)
                     if resource.get('status') == DELETED_STATUS:
@@ -981,7 +981,7 @@ class AciToAimModelConverter(BaseConverter):
                     del resource['displayName']
             except Exception as e:
                 LOG.warn("Could not convert object"
-                         "%s with error %s" % (object, e.message))
+                         "%s with error %s" % (object, str(e)))
                 LOG.debug(traceback.format_exc())
         squashed = self._squash(result)
         if aci_objects:
@@ -1004,7 +1004,7 @@ class AciToAimModelConverter(BaseConverter):
                 (res._aci_mo_name,) + tuple(res.identity),
                 klass(**dict([(y, res.identity[x]) for x, y in
                               enumerate(klass.identity_attributes)])))
-            for k, v in res.__dict__.iteritems():
+            for k, v in res.__dict__.items():
                 if isinstance(v, list):
                     for item in v:
                         if isinstance(item, dict) and '_converter_id' in item:
@@ -1018,7 +1018,7 @@ class AciToAimModelConverter(BaseConverter):
                         current.__dict__.setdefault(k, []).append(item)
                 else:
                     setattr(current, k, v)
-        return res_map.values()
+        return list(res_map.values())
 
 
 class AimToAciModelConverter(BaseConverter):
@@ -1068,7 +1068,7 @@ class AimToAciModelConverter(BaseConverter):
                     del object.__dict__['name_alias']
             except Exception as e:
                 LOG.warn("Could not convert object"
-                         "%s with error %s" % (object.__dict__, e.message))
+                         "%s with error %s" % (object.__dict__, str(e)))
                 LOG.debug(traceback.format_exc())
 
         squashed = self._squash(result)
@@ -1085,6 +1085,6 @@ class AimToAciModelConverter(BaseConverter):
         res_map = collections.OrderedDict()
         for res in converted_list:
             current = res_map.setdefault(
-                res[res.keys()[0]]['attributes']['dn'], res)
+                res[list(res.keys())[0]]['attributes']['dn'], res)
             current.update(res)
-        return res_map.values()
+        return list(res_map.values())

--- a/aim/agent/aid/universes/aci/converters/service_graph.py
+++ b/aim/agent/aid/universes/aci/converters/service_graph.py
@@ -157,7 +157,7 @@ def service_graph_converter(object_dict, otype, helper,
         lc_nodes = [n for n in object_dict['linear_chain_nodes']
                     if n.get('name')]
 
-        prev_conn = term_cons.values()[0]['attributes']['dn']
+        prev_conn = list(term_cons.values())[0]['attributes']['dn']
         cntr = 0
         for fn in lc_nodes:
             cntr = cntr + 1
@@ -182,8 +182,9 @@ def service_graph_converter(object_dict, otype, helper,
             cxn = service_graph.ServiceGraphConnection(
                 tenant_name=tn, service_graph_name=gr, name='C%s' % (cntr + 1),
                 unicast_route=True,
-                connector_dns=[prev_conn,
-                               term_prov.values()[0]['attributes']['dn']])
+                connector_dns=[
+                    prev_conn,
+                    list(term_prov.values())[0]['attributes']['dn']])
             result.append(cxn)
     return result
 

--- a/aim/agent/aid/universes/aci/converters/utils.py
+++ b/aim/agent/aid/universes/aci/converters/utils.py
@@ -94,7 +94,7 @@ def default_to_resource(converted, helper, to_aim=True):
         # APIC to AIM
         return klass(
             _set_default=False,
-            **dict([(k, v) for k, v in converted.iteritems() if k in
+            **dict([(k, v) for k, v in converted.items() if k in
                     klass.attributes() and k not in skip]))
     else:
         for s in default_skip + skip:
@@ -109,7 +109,7 @@ def default_to_resource_strict(converted, helper, to_aim=True):
     else:
         # Only include explicitly mentioned attributes
         values = {}
-        for k, v in helper.get('exceptions', {}).iteritems():
+        for k, v in helper.get('exceptions', {}).items():
             attr = v.get('other') or k
             skip_if_empty = v.get('skip_if_empty', False)
             conv_value = converted.get(attr)
@@ -218,7 +218,7 @@ def default_converter(object_dict, otype, helper,
             others = do_attribute_conversion(object_dict, attribute,
                                              helper.get('exceptions', {}),
                                              to_aim=to_aim)
-            for other_k, other_v in others.iteritems():
+            for other_k, other_v in others.items():
                 # Identity was already converted
                 if other_k not in destination_identity_attributes:
                     res_dict[other_k] = other_v
@@ -259,7 +259,7 @@ def child_list(aim_attr, aci_attr, aci_mo=None):
 
 def reverse_attribute_mapping_info(mapping_info, to_aim=True):
     result = {}
-    for exception, value in mapping_info.iteritems():
+    for exception, value in mapping_info.items():
         other_name = value.get(
             'other', convert_attribute(exception, to_aim=to_aim))
         result[other_name] = {'other': exception}
@@ -305,14 +305,14 @@ def list_dict(aim_attr, mapping_info, id_attr, aci_mo=None, requires=None):
             for aim_list_item in object_dict[aim_attr]:
                 req = set(requires or [])
                 aim_list_item = copy.copy(aim_list_item)
-                for k, v in aim_list_item.iteritems():
+                for k, v in aim_list_item.items():
                     if k in req and not v:
                         break
                     req.discard(k)
                 if req:
                     continue
                 # fill out the defaults
-                for aim_d_a, map_info in mapping_info.iteritems():
+                for aim_d_a, map_info in mapping_info.items():
                     if aim_d_a not in aim_list_item and 'default' in map_info:
                         aim_list_item[aim_d_a] = map_info['default']
                 extra_attr = []
@@ -322,7 +322,7 @@ def list_dict(aim_attr, mapping_info, id_attr, aci_mo=None, requires=None):
                                                        mapping_info,
                                                        to_aim=False)
                         if conv:
-                            extra_attr.append(conv.values()[0])
+                            extra_attr.append(list(conv.values())[0])
                 if len(extra_attr) == len(id_attr):
                     dn = id_conv(object_dict, otype, helper,
                                  extra_attributes=extra_attr,

--- a/aim/agent/aid/universes/aci/error.py
+++ b/aim/agent/aid/universes/aci/error.py
@@ -48,10 +48,10 @@ class APICErrorHandler(object):
         elif isinstance(e, request_exc.InvalidURL):
             return errors.OPERATION_CRITICAL
         elif isinstance(e, request_exc.RequestException):
-            LOG.warn("A generic request exception occurred: %s", e.message)
+            LOG.warn("A generic request exception occurred: %s", str(e))
             return errors.OPERATION_TRANSIENT
         else:
-            LOG.warn("An unknown error occurred: %s", e.message)
+            LOG.warn("An unknown error occurred: %s", str(e))
             return errors.UNKNOWN
 
     def analyze_apic_error(self, error_status, error_code):

--- a/aim/agent/aid/universes/aim_universe.py
+++ b/aim/agent/aid/universes/aim_universe.py
@@ -139,7 +139,7 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
         # Deletion candidates will be decided solely by the AIM configuration
         # universe.
         my_state = self.state
-        for tenant, tree in my_state.iteritems():
+        for tenant, tree in my_state.items():
             if not tree.root and tenant not in vetoes:
                 # The desired state for this tentant is empty
                 delete_candidates.add(tenant)
@@ -190,11 +190,11 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
                     self._push_resource(context, resource, method, monitored)
                 except aim_exc.InvalidMonitoredStateUpdate as e:
                     msg = ("Failed to %s object %s in AIM: %s." %
-                           (method, resource, e.message))
+                           (method, resource, str(e)))
                     LOG.warn(msg)
                 except Exception as e:
                     LOG.error("Failed to %s object %s in AIM: %s." %
-                              (method, resource, e.message))
+                              (method, resource, str(e)))
                     LOG.debug(traceback.format_exc())
                     if method == 'delete':
                         self.deletion_failed(context, resource)
@@ -314,7 +314,7 @@ class AimDbUniverse(base.HashTreeStoredUniverse):
         else:
             # it's in ACI format
             return tree_manager.AimHashTreeMaker._extract_root_from_dn(
-                res.values()[0]['attributes']['dn'])
+                list(res.values())[0]['attributes']['dn'])
 
 
 class AimDbOperationalUniverse(AimDbUniverse):
@@ -395,7 +395,7 @@ class AimDbMonitoredUniverse(AimDbUniverse):
                                  delete_candidates, vetoes):
         my_state = self.state
         # Veto tenants with non-dummy roots
-        for tenant, tree in my_state.iteritems():
+        for tenant, tree in my_state.items():
             if tree.root and not tree.root.dummy:
                 delete_candidates.discard(tenant)
                 vetoes.add(tenant)
@@ -421,8 +421,8 @@ class AimDbMonitoredUniverse(AimDbUniverse):
 
         def action(result, aci_object, node):
             key = tree_manager.AimHashTreeMaker._dn_to_key(
-                aci_object.keys()[0],
-                aci_object.values()[0]['attributes']['dn'])
+                list(aci_object.keys())[0],
+                list(aci_object.values())[0]['attributes']['dn'])
             if len(key) == 1:
                 LOG.debug('Skipping delete for monitored root object: %s '
                           % aci_object)

--- a/aim/agent/aid/universes/base_universe.py
+++ b/aim/agent/aid/universes/base_universe.py
@@ -424,7 +424,7 @@ class HashTreeStoredUniverse(AimUniverse):
                 self.push_resources(context, result)
             except Exception as e:
                 LOG.error("An unexpected error has occurred while "
-                          "reconciling tenant %s: %s" % (tenant, e.message))
+                          "reconciling tenant %s: %s" % (tenant, str(e)))
                 LOG.error(traceback.format_exc())
                 # Guess we can't consider the multiverse synced if this happens
                 diff = True
@@ -461,8 +461,8 @@ class HashTreeStoredUniverse(AimUniverse):
                 related = attr.pop('related', False)
                 attr = attr.get('attributes', {})
                 aci_object = self._keys_to_bare_aci_objects([key])[0]
-                aci_object.values()[0]['attributes'].update(attr)
-                dn = aci_object.values()[0]['attributes']['dn']
+                list(aci_object.values())[0]['attributes'].update(attr)
+                dn = list(aci_object.values())[0]['attributes']['dn']
                 # Capture related objects
                 if desired_state:
                     self._fill_related_nodes(resource_keys, key,

--- a/aim/agent/aid/universes/k8s/k8s_watcher.py
+++ b/aim/agent/aid/universes/k8s/k8s_watcher.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import Queue as queue
+from six.moves import queue
 import time
 import traceback
 
@@ -125,7 +125,7 @@ class K8sWatcher(object):
         except Exception as e:
             LOG.error(traceback.format_exc())
             utils.perform_harakiri(LOG, "%s thread stopped "
-                                        "unexpectedly: %s" % (name, e.message))
+                                        "unexpectedly: %s" % (name, str(e)))
 
     def _pod_event_filter(self, event):
         obj = event.get('object', {})

--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -194,11 +194,11 @@ class AimManager(object):
                 if (fix_ownership and old_monitored is not None and
                         old_monitored != new_monitored):
                     raise exc.InvalidMonitoredStateUpdate(object=resource)
-                attr_val = {k: v for k, v in update_attr_val.iteritems()
+                attr_val = {k: v for k, v in update_attr_val.items()
                             if k in resource.other_attributes.keys()}
                 if attr_val:
                     old_resource_copy = copy.deepcopy(old_resource)
-                    for k, v in attr_val.iteritems():
+                    for k, v in attr_val.items():
                         setattr(old_resource, k, v)
                     if old_resource.user_equal(
                             old_resource_copy) and not force_update:
@@ -206,7 +206,7 @@ class AimManager(object):
                         return old_resource
                 elif resource.identity_attributes:
                     # force update
-                    id_attr_0 = resource.identity_attributes.keys()[0]
+                    id_attr_0 = list(resource.identity_attributes.keys())[0]
                     attr_val = {id_attr_0: getattr(resource, id_attr_0)}
                 context.store.from_attr(db_obj, type(resource), attr_val)
                 context.store.add(db_obj)
@@ -265,7 +265,7 @@ class AimManager(object):
         Returns a list of resources that match.
         """
         self._validate_resource_class(resource_class)
-        attr_val = {k: v for k, v in kwargs.iteritems()
+        attr_val = {k: v for k, v in kwargs.items()
                     if k in resource_class.attributes() +
                     ['in_', 'notin_', 'order_by']}
         return self._delete_db(context.store, resource_class, **attr_val)
@@ -310,7 +310,7 @@ class AimManager(object):
         Returns a list of resources that match.
         """
         self._validate_resource_class(resource_class)
-        attr_val = {k: v for k, v in kwargs.iteritems()
+        attr_val = {k: v for k, v in kwargs.items()
                     if k in resource_class.attributes() +
                     ['in_', 'notin_', 'order_by']}
         result = []
@@ -323,7 +323,7 @@ class AimManager(object):
 
     def count(self, context, resource_class, **kwargs):
         self._validate_resource_class(resource_class)
-        attr_val = {k: v for k, v in kwargs.iteritems()
+        attr_val = {k: v for k, v in kwargs.items()
                     if k in resource_class.attributes() +
                     ['in_', 'notin_', 'order_by']}
         return self._count_db(context.store, resource_class, **attr_val)
@@ -517,7 +517,7 @@ class AimManager(object):
 
         def get_subtree_klasses(klass):
             for child_klass in self._model_tree.get(klass, []):
-                id = {child_klass.identity_attributes.keys()[i]: v
+                id = {list(child_klass.identity_attributes.keys())[i]: v
                       for i, v in enumerate(identity)}
                 # Extra search attributes
                 id.update(kwargs)

--- a/aim/api/schema.py
+++ b/aim/api/schema.py
@@ -33,11 +33,11 @@ def generate_schema():
          ("properties", top_properties),
          ("definitions", definitions)])
     for klass in writable_classes:
-        required = klass.identity_attributes.keys()
+        required = list(klass.identity_attributes.keys())
         properties = {}
         for attr in [klass.identity_attributes, klass.other_attributes,
                      klass.db_attributes]:
-            for k, v in attr.iteritems():
+            for k, v in attr.items():
                 properties[k] = v
         title = klass.__name__
         name = utils.camel_to_snake(title)

--- a/aim/api/status.py
+++ b/aim/api/status.py
@@ -145,6 +145,18 @@ class AciFault(resource.ResourceBase, OperationalResource):
         except AttributeError:
             return False
 
+    # An object is hashable if it has a hash value which never changes during
+    # its lifetime (it needs a __hash__() method), and can be compared to
+    # other objects (it needs an __eq__() or __cmp__() method).
+    # Hashable objects which compare equal must have the same hash value.
+    #
+    # If you define __eq__() , the default __hash__() (namely, hashing the
+    # address of the object in memory) goes away.
+    # So for each class defining __eq__() we must also
+    # define __hash__() even though parent class has __hash__().
+    def __hash__(self):
+        return super(AciFault, self).__hash__()
+
     def __init__(self, **kwargs):
         super(AciFault, self).__init__(
             {'severity': self.SEV_INFO, 'lifecycle_status': self.LC_UNKNOWN,

--- a/aim/api/types.py
+++ b/aim/api/types.py
@@ -72,7 +72,6 @@ def list_of_dicts(*dict_keys_and_types):
             "items": {"type": "object",
                       "properties": dict(dict_keys_and_types)}}
 
-
 bool = {"type": "boolean"}
 integer = {"type": "integer"}
 name = {"type": "string", "pattern": "^[a-zA-Z0-9_.:-]{0,63}$"}

--- a/aim/common/hashtree/base.py
+++ b/aim/common/hashtree/base.py
@@ -17,6 +17,8 @@ import abc
 import bisect
 import six
 
+from aim.common import utils
+
 
 @six.add_metaclass(abc.ABCMeta)
 class ComparableCollection(object):
@@ -181,7 +183,16 @@ class OrderedList(object):
         return len(self._stash)
 
     def __cmp__(self, other):
-        return cmp(self._stash, other._stash)
+        return utils.cmp(self._stash, other._stash)
+
+    # In Py3, all objects that implemented __cmp__ must be updated to
+    # implement some of the rich methods instead like __eq__, __lt__, etc.
+    # Here, __eq__ and __lt__ are sufficient for comparison.
+    def __eq__(self, other):
+        return (self._stash == other._stash)
+
+    def __lt__(self, other):
+        return (self._stash < other._stash)
 
     def __nonzero__(self):
         return len(self) != 0

--- a/aim/config.py
+++ b/aim/config.py
@@ -211,8 +211,8 @@ class ConfigManager(object):
         host = host or ''
         # Create a DB session
         result = {}
-        for group, congifs in self.map.iteritems():
-            for k, v in congifs.iteritems():
+        for group, congifs in self.map.items():
+            for k, v in congifs.items():
                 try:
                     if group == 'default':
                         value = getattr(cfg_obj, k)
@@ -484,7 +484,7 @@ class ConfigSubscriber(utils.AIMThread):
         call_id = self._get_call_id(callback)
         # Copy to avoid runtime changes
         for group, items in copy.deepcopy(self.map_by_callback_id.get(
-                call_id, {})).iteritems():
+                call_id, {})).items():
             for item in items:
                 self.unregister_callback_option(callback, item, group)
 
@@ -503,16 +503,16 @@ class ConfigSubscriber(utils.AIMThread):
                                       readable_caller='Config Subscriber')
         except Exception as e:
             LOG.error("An exception has occurred in config subscriber thread "
-                      "%s" % e.message)
+                      "%s" % str(e))
             LOG.error(traceback.format_exc())
 
     def _poll_and_execute(self):
         # prepare call
         configs = {}
         # Copy the sub dictionary which might change during the iteration
-        for group, items in copy.copy(self.subscription_map).iteritems():
-            for item, callbacks in copy.copy(items).iteritems():
-                for call_id, values in copy.copy(callbacks).iteritems():
+        for group, items in copy.copy(self.subscription_map).items():
+            for item, callbacks in copy.copy(items).items():
+                for call_id, values in copy.copy(callbacks).items():
                     for host in values['hosts']:
                         try:
                             # TODO(ivar): optimize to make a single DB call
@@ -535,7 +535,7 @@ class ConfigSubscriber(utils.AIMThread):
                             LOG.error(
                                 "An exception has occurred while "
                                 "executing callback %s: %s" % (
-                                    values['callback'], e.message))
+                                    values['callback'], str(e)))
                             LOG.error(traceback.format_exc())
 
     def _get_call_id(self, callback):

--- a/aim/db/config_model.py
+++ b/aim/db/config_model.py
@@ -82,7 +82,7 @@ class ConfigurationDBManager(object):
         :return:
         """
         with context.store.begin(subtransactions=True):
-            for conf, v in configs.iteritems():
+            for conf, v in configs.items():
                 group, key, host = conf
                 cfg = resource.Configuration(group=group, key=key, host=host,
                                              value=v)

--- a/aim/db/hashtree_db_listener.py
+++ b/aim/db/hashtree_db_listener.py
@@ -302,7 +302,7 @@ class HashTreeDbListener(object):
                         self._delete_logs(ctx, log_by_root[root_rn])
             except Exception as e:
                 LOG.error('Failed to update root %s '
-                          'tree for: %s' % (root_rn, e.message))
+                          'tree for: %s' % (root_rn, str(e)))
                 LOG.debug(traceback.format_exc())
 
     def _validate_config_trees(self, ctx, roots):

--- a/aim/db/migration/data_migration/status_add_tenant.py
+++ b/aim/db/migration/data_migration/status_add_tenant.py
@@ -62,11 +62,13 @@ def migrate(session):
             elif len(root_klass.identity_attributes) == 0:
                 rn = root_klass().rn
             else:
-                parent_root_attr = parent_class.identity_attributes.keys()[0]
+                parent_root_attr = list(
+                    parent_class.identity_attributes.keys())[0]
                 parent_root = getattr(parent_table, parent_root_attr)
                 parent = session.query(parent_root).one()
                 root_name = getattr(parent, parent_root_attr)
                 rn = root_klass(
-                    **{root_klass.identity_attributes.keys()[0]: root_name}).rn
+                    **{list(root_klass.identity_attributes.keys(
+                        ))[0]: root_name}).rn
             session.execute(update(Status).where(
                 Status.c.id == st.id).values(resource_root=rn))

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -14,9 +14,9 @@
 # under the License.
 
 import logging  # noqa
+import mock
 import os
 
-import mock
 from oslo_config import cfg
 from oslo_log import log as o_log
 from oslo_utils import uuidutils
@@ -53,10 +53,6 @@ def etcdir(*p):
     return os.path.join(ETCDIR, *p)
 
 
-def sort_if_list(attr):
-    return sorted(attr) if isinstance(attr, list) else attr
-
-
 def resource_equal(self, other):
 
     if type(self) != type(other):
@@ -65,8 +61,8 @@ def resource_equal(self, other):
         if getattr(self, attr) != getattr(other, attr):
             return False
     for attr in self.other_attributes:
-        if (sort_if_list(getattr(self, attr, None)) !=
-                sort_if_list(getattr(other, attr, None))):
+        if (utils.deep_sort(getattr(self, attr, None)) !=
+                utils.deep_sort(getattr(other, attr, None))):
             return False
     return True
 

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -75,9 +75,9 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
 
         # Test same tenants cause a noop
         serving_tenants_copy = dict(
-            [(k, v) for k, v in self.universe.serving_tenants.iteritems()])
+            [(k, v) for k, v in self.universe.serving_tenants.items()])
         self.universe.serve(self.ctx, tenant_list)
-        for k, v in serving_tenants_copy.iteritems():
+        for k, v in serving_tenants_copy.items():
             # Serving tenant values are the same
             self.assertIs(v, self.universe.serving_tenants[k])
 
@@ -86,7 +86,7 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         self.universe.serving_tenants['tn-19'].is_dead = mock.Mock(
             return_value=True)
         self.universe.serve(self.ctx, tenant_list)
-        for k, v in serving_tenants_copy.iteritems():
+        for k, v in serving_tenants_copy.items():
             if k != 'tn-19':
                 # Serving tenant values are the same
                 self.assertIs(v, self.universe.serving_tenants[k])
@@ -229,7 +229,8 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
                  'vzRsFiltAtt|h'),
                 ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s')]
         result = self.universe.get_resources(keys)
-        self.assertEqual(sorted(objs), sorted(result))
+        self.assertEqual(utils.deep_sort(objs),
+                         utils.deep_sort(result))
 
     # TODO(kentwu): need to enable this test case
     @base.requires(['skip'])
@@ -251,7 +252,7 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
                 ('fvTenant|t1', 'vzBrCP|c', 'vzSubj|s',
                  'vzOutTerm|outtmnl', 'vzRsFiltAtt|h')]
         result = self.universe.get_resources_for_delete(keys)
-        self.assertEqual(sorted(objs), sorted(result))
+        self.assertEqual(utils.deep_sort(objs), utils.deep_sort(result))
         # Create a pending monitored object
         tn1 = resource.Tenant(name='tn1', monitored=True)
         monitored_bd = resource.BridgeDomain(
@@ -268,7 +269,7 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         result = result[0]
         self.assertEqual('tagInst', result.keys()[0])
         self.assertEqual('uni/tn-tn1/BD-monitoredBD/tag-openstack_aid',
-                         result.values()[0]['attributes']['dn'])
+                         list(result.values())[0]['attributes']['dn'])
 
         # Delete an RS-node of a monitored object
         self.universe.manager.create(self.ctx, resource.L3Outside(
@@ -287,7 +288,7 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         result = result[0]
         self.assertEqual('fvRsProv', result.keys()[0])
         self.assertEqual('uni/tn-tn1/out-out/instP-inet/rsprov-p1',
-                         result.values()[0]['attributes']['dn'])
+                         list(result.values())[0]['attributes']['dn'])
 
     def test_ws_config_changed(self):
         # Refresh subscriptions
@@ -358,7 +359,7 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         self.assertEqual(1, len(self.universe._sync_log['tn-t2']['create']))
         # BD counted only once
         self.assertEqual(
-            0, self.universe._sync_log['tn-t1']['create'].values()[0][
+            0, list(self.universe._sync_log['tn-t1']['create'].values())[0][
                 'retries'])
         ctrl = resource.VMMController(domain_type='OpenStack',
                                       domain_name='os', name='ctrl')
@@ -389,10 +390,10 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
                                                                    'tn-t1')
         # BD count increased
         self.assertEqual(
-            1, self.universe._sync_log['tn-t1']['create'].values()[0][
+            1, list(self.universe._sync_log['tn-t1']['create'].values())[0][
                 'retries'])
         self.assertEqual(
-            0, self.universe._sync_log[ctrl.root]['delete'].values()[0][
+            0, list(self.universe._sync_log[ctrl.root]['delete'].values())[0][
                 'retries'])
         # Retry the above until t1 needs reset
         for _ in range(reset_limit - 1):
@@ -436,7 +437,7 @@ class TestAciUniverse(TestAciUniverseMixin, base.TestAimDBBase):
         self.universe.serve(self.ctx, tenant_list)
         self.assertIs(self.universe.serving_tenants,
                       operational.serving_tenants)
-        for key, value in self.universe.serving_tenants.iteritems():
+        for key, value in self.universe.serving_tenants.items():
             self.assertIs(operational.serving_tenants[key], value)
 
     def test_track_universe_actions(self):

--- a/aim/tests/unit/agent/aid_universes/test_aim_db_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aim_db_universe.py
@@ -489,7 +489,7 @@ class TestAimDbUniverse(TestAimDbUniverseBase, base.TestAimDBBase):
         self.assertEqual(1, len(self.universe._sync_log['tn-t1']['create']))
         # BD counted only once
         self.assertEqual(
-            0, self.universe._sync_log['tn-t1']['create'].values()[0][
+            0, list(self.universe._sync_log['tn-t1']['create'].values())[0][
                 'retries'])
         actions = {
             'create': [
@@ -520,10 +520,10 @@ class TestAimDbUniverse(TestAimDbUniverseBase, base.TestAimDBBase):
                                                                    'tn-t1')
         # BD count increased
         self.assertEqual(
-            1, self.universe._sync_log['tn-t1']['create'].values()[0][
+            1, list(self.universe._sync_log['tn-t1']['create'].values())[0][
                 'retries'])
         self.assertEqual(
-            0, self.universe._sync_log[ctrl.root]['delete'].values()[0][
+            0, list(self.universe._sync_log[ctrl.root]['delete'].values())[0][
                 'retries'])
         # Retry the above until t1 needs reset
         for _ in range(reset_limit - 1):

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -87,7 +87,7 @@ class TestAciToAimConverterBase(object):
 
     def _test_deleted_object(self, example, expected):
         for item in example:
-            item.values()[0]['status'] = 'deleted'
+            list(item.values())[0]['status'] = 'deleted'
         for item in expected:
             item._status = 'deleted'
         result = self.converter.convert(example)
@@ -105,7 +105,7 @@ class TestAciToAimConverterBase(object):
                          '\nExpected:\n%s\nFound:\n%s' %
                             (pprint.pformat(expected),
                              pprint.pformat(reverse)))
-        for idx in xrange(len(expected)):
+        for idx in range(len(expected)):
             self.assertTrue(expected[idx] in reverse,
                             '\nExpected:\n%s\nnot in\n%s' %
                             (pprint.pformat(expected[idx]),

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -141,13 +141,13 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
     def _tree_to_event(self, root, result, dn, manager):
         if not root:
             return
-        children = root.values()[0]['children']
-        root.values()[0]['children'] = []
-        dn += '/' + root.values()[0]['attributes']['rn']
-        root.values()[0]['attributes']['dn'] = dn
-        status = root.values()[0]['attributes'].get('status')
+        children = list(root.values())[0]['children']
+        list(root.values())[0]['children'] = []
+        dn += '/' + list(root.values())[0]['attributes']['rn']
+        list(root.values())[0]['attributes']['dn'] = dn
+        status = list(root.values())[0]['attributes'].get('status')
         if status is None:
-            root.values()[0]['attributes']['status'] = 'created'
+            list(root.values())[0]['attributes']['status'] = 'created'
         elif status == 'deleted':
             # API call fails in case the item doesn't exist
             if not test_aci_tenant.mock_get_data(manager.aci_session,
@@ -394,7 +394,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # Push state
         currentserving_tenants = {
             k: v for k, v in
-            agent.current_universe.serving_tenants.iteritems()}
+            agent.current_universe.serving_tenants.items()}
         agent._reconciliation_cycle()
         self.assertIs(agent.current_universe.serving_tenants[tn1.rn],
                       currentserving_tenants[tn1.rn])
@@ -1618,7 +1618,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # Action cache is empty
         self.assertEqual({}, desired_monitor._sync_log)
         self.assertEqual({'create': {}, 'delete': {}},
-                         current_monitor._sync_log.values()[0])
+                         list(current_monitor._sync_log.values())[0])
 
     def test_tenant_delete_behavior(self):
         tenant_name = 'test_tenant_delete_behavior'
@@ -2167,7 +2167,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
 
         def printable_state(universe):
             return json.dumps({x: y.root.to_dict() if y.root else {}
-                               for x, y in universe.state.iteritems()},
+                               for x, y in universe.state.items()},
                               indent=2)
         desired.observe(self.ctx)
         current.observe(self.ctx)
@@ -2248,7 +2248,8 @@ class TestAgentAnnotation(TestAgent):
             obj = test_aci_tenant.mock_get_data(
                 desired_monitor.serving_tenants[tenant_rn].aci_session,
                 'mo/' + dn)
-            return obj[0].values()[0]['attributes'].get('annotation', False)
+            return list(obj[0].values())[0]['attributes'].get(
+                'annotation', False)
         except apic_client.cexc.ApicResponseNotOk:
             # Fallback to tags
             try:

--- a/aim/tests/unit/aim_lib/test_nat_strategy.py
+++ b/aim/tests/unit/aim_lib/test_nat_strategy.py
@@ -25,6 +25,7 @@ import copy
 from aim.aim_lib import nat_strategy
 from aim import aim_manager
 from aim.api import resource as a_res
+from aim.common import utils
 from aim.tests import base
 
 
@@ -44,7 +45,7 @@ class TestNatStrategyBase(object):
 
     def _assert_res_eq(self, lhs, rhs):
         def sort_if_list(obj):
-            return sorted(obj) if isinstance(obj, list) else obj
+            return utils.deep_sort(obj)
 
         self.assertEqual(type(lhs), type(rhs))
         for attr in lhs.user_attributes():
@@ -778,19 +779,19 @@ class TestNoNatStrategy(TestNatStrategyBase, base.TestAimDBBase):
                                  limit_ip_learn_to_subnets=True,
                                  l3out_names=['o1'])
         if stage == 'stage1':
-            self._verify(present=objs.values() + l3out_objs + [bd1])
+            self._verify(present=list(objs.values()) + l3out_objs + [bd1])
         elif stage == 'stage2' or stage == 'stage3':
             l3out.vrf_name = 'vrf2'
             ext_net.provided_contract_names = ['EXT-o1', 'p1_vrf2', 'p2_vrf2']
             ext_net.consumed_contract_names = ['EXT-o1', 'c1_vrf2', 'c2_vrf2']
-            self._verify(present=objs.values() + l3out_objs + [bd1, bd2])
+            self._verify(present=list(objs.values()) + l3out_objs + [bd1, bd2])
         elif stage == 'stage4':
             bd2.l3out_names = []
             nat_bd.vrf_name = 'EXT-o1'
             l3out.vrf_name = 'vrf2'
             ext_net.provided_contract_names = ['EXT-o1']
             ext_net.consumed_contract_names = ['EXT-o1']
-            self._verify(present=objs.values() + l3out_objs + [bd1, bd2])
+            self._verify(present=list(objs.values()) + l3out_objs + [bd1, bd2])
         else:
             self.assertFalse(True, 'Unknown test stage %s' % stage)
 
@@ -799,7 +800,7 @@ class TestNoNatStrategy(TestNatStrategyBase, base.TestAimDBBase):
         objs.pop('ext_sub_1')
         objs.pop('ext_sub_2')
         e1 = objs.pop('ext_net')
-        objs = objs.values()
+        objs = list(objs.values())
 
         e2 = copy.deepcopy(e1)
         e2.provided_contract_names = ['EXT-o1', 'arp', 'p2_vrf1']
@@ -850,7 +851,7 @@ class TestNoNatStrategy(TestNatStrategyBase, base.TestAimDBBase):
             v1_e2 = self._get_vrf_1_ext_net_2_objects(connected=False).values()
         else:
             self.assertFalse(True, 'Unknown test stage %s' % stage)
-        self._verify(present=(v1_e1 + v1_e2))
+        self._verify(present=(list(v1_e1) + list(v1_e2)))
 
     def _check_delete_ext_net_with_vrf(self, stage):
         if stage == 'stage1':
@@ -860,22 +861,22 @@ class TestNoNatStrategy(TestNatStrategyBase, base.TestAimDBBase):
                                                        'p2_vrf2']
             objs['ext_net'].consumed_contract_names = ['EXT-o1', 'c1_vrf2',
                                                        'c2_vrf2']
-            self._verify(present=objs.values())
+            self._verify(present=list(objs.values()))
         elif stage == 'stage2':
             objs = self._get_vrf_1_ext_net_1_objects(connected=False)
             l3out = objs.pop('l3out')
             nat_bd = objs.pop('nat_bd')
             l3out.vrf_name = 'vrf2'
-            self._verify(present=[l3out, nat_bd], absent=objs.values())
+            self._verify(present=[l3out, nat_bd], absent=list(objs.values()))
         else:
             self.assertFalse(True, 'Unknown test stage %s' % stage)
 
     def _check_delete_l3outside_with_vrf(self, stage):
         objs = self._get_vrf_1_ext_net_1_objects()
         if stage == 'stage1':
-            self._verify(present=objs.values())
+            self._verify(present=list(objs.values()))
         elif stage == 'stage2':
-            self._verify(absent=objs.values())
+            self._verify(absent=list(objs.values()))
         else:
             self.assertFalse(True, 'Unknown test stage %s' % stage)
 

--- a/aim/tests/unit/test_migration.py
+++ b/aim/tests/unit/test_migration.py
@@ -71,23 +71,24 @@ class TestDataMigration(base.TestAimDBBase):
                 interface_profile_name='dc2', interface_path='h2/path'))
         add_host_column.migrate(self.ctx.db_session)
         epg1 = self.mgr.get(self.ctx, epg1)
-        self.assertEqual(sorted([{'path': 'h1/path/2', 'encap': '100',
-                                  'host': 'h1'},
-                                 {'path': 'h2/path', 'encap': '100',
-                                  'host': 'h2'},
-                                 {'path': 'not_known', 'encap': '100'}]),
-                         sorted(epg1.static_paths))
+        self.assertEqual(
+            utils.deep_sort(
+                [{'path': 'h1/path/2', 'encap': '100', 'host': 'h1'},
+                 {'path': 'h2/path', 'encap': '100', 'host': 'h2'},
+                 {'path': 'not_known', 'encap': '100'}]),
+            utils.deep_sort(epg1.static_paths))
         epg2 = self.mgr.get(self.ctx, epg2)
-        self.assertEqual(sorted([{'path': 'h1/path/2', 'encap': '100',
-                                  'host': 'h1'},
-                                 {'path': 'h1/path/VPC', 'encap': '100',
-                                  'host': 'h1'}]),
-                         sorted(epg2.static_paths))
+        self.assertEqual(
+            utils.deep_sort(
+                [{'path': 'h1/path/2', 'encap': '100', 'host': 'h1'},
+                 {'path': 'h1/path/VPC', 'encap': '100', 'host': 'h1'}]),
+            utils.deep_sort(epg2.static_paths))
         dc = self.mgr.get(self.ctx, dc)
-        self.assertEqual(sorted([{'path': 'h1/path/2', 'name': '1',
-                                  'host': 'h1'},
-                                 {'path': 'h2/path', 'name': '2',
-                                  'host': 'h2'}]), sorted(dc.devices))
+        self.assertEqual(
+            utils.deep_sort(
+                [{'path': 'h1/path/2', 'name': '1', 'host': 'h1'},
+                 {'path': 'h2/path', 'name': '2', 'host': 'h2'}]),
+            utils.deep_sort(dc.devices))
         cdi1 = self.mgr.get(self.ctx, cdi1)
         self.assertEqual('h1', cdi1.host)
         cdi2 = self.mgr.get(self.ctx, cdi2)

--- a/aim/tests/unit/test_structured_hash_tree.py
+++ b/aim/tests/unit/test_structured_hash_tree.py
@@ -205,7 +205,7 @@ class TestStructuredHashTree(base.BaseTestCase):
             return False
         if any(not self._tree_deep_check(root1.get_children()[x],
                                          root2.get_children()[x])
-               for x in xrange(len(root1.get_children()))):
+               for x in range(len(root1.get_children()))):
             return False
         return True
 
@@ -748,7 +748,7 @@ class TestHashTreeManager(base.TestAimDBBase):
                        data2.root.key[0]: data2.root.full_hash,
                        data3.root.key[0]: data3.root.full_hash})
         self.assertEqual(1, len(changed))
-        self.assertEqual(data1.root.key, changed.values()[0].root.key)
+        self.assertEqual(data1.root.key, list(changed.values())[0].root.key)
 
     def test_get_tenants(self):
         data1 = tree.StructuredHashTree().include(
@@ -882,12 +882,12 @@ class TestAimHashTreeMaker(base.TestAimDBBase):
         self.assertEqual(exp_tree, htree)
         self.assertEqual(
             {"attributes": mock.ANY, "monitored": False},
-            htree.find(bd_key).metadata.to_dict())
+            htree.find(bd_key).metadata)
         self.assertEqual({'related': True, "attributes": mock.ANY,
                           "monitored": False},
-                         htree.find(rsctx_key).metadata.to_dict())
+                         htree.find(rsctx_key).metadata)
         self.assertEqual({"attributes": mock.ANY, "monitored": False},
-                         htree.find(subnet_key).metadata.to_dict())
+                         htree.find(subnet_key).metadata)
 
         bd.name = 'bd2'
         subnet.bd_name = 'bd2'
@@ -913,12 +913,12 @@ class TestAimHashTreeMaker(base.TestAimDBBase):
         self.assertEqual(exp_tree, htree)
         self.assertEqual(exp_tree, htree)
         self.assertEqual({"attributes": mock.ANY, "monitored": False},
-                         htree.find(bd_key).metadata.to_dict())
+                         htree.find(bd_key).metadata)
         self.assertEqual(
             {"attributes": mock.ANY, "monitored": False, 'related': True},
-            htree.find(rsctx_key).metadata.to_dict())
+            htree.find(rsctx_key).metadata)
         self.assertEqual({"attributes": mock.ANY, "monitored": False},
-                         htree.find(subnet_key).metadata.to_dict())
+                         htree.find(subnet_key).metadata)
 
     def test_update_1(self):
         htree = tree.StructuredHashTree()

--- a/aim/tools/cli/commands/manager.py
+++ b/aim/tools/cli/commands/manager.py
@@ -94,7 +94,7 @@ def filter_kwargs(klass, kwargs):
     res = {}
     LOG.debug('args: %s', kwargs)
     dummy = klass(**{k: kwargs[k] for k in klass.identity_attributes})
-    for k, v in kwargs.iteritems():
+    for k, v in kwargs.items():
         if v is not ATTR_UNSPECIFIED:
             try:
                 attr_type = klass.other_attributes.get(k)
@@ -168,7 +168,7 @@ def update(klass):
         aim_ctx = ctx.obj['aim_ctx']
         id = {}
         mod = {}
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             if k in klass.identity_attributes:
                 id[k] = v
             else:
@@ -256,7 +256,7 @@ def get_domains(aim_ctx, manager, create_doms=True):
             res = resource.VMMPolicy(type=type_, monitored=True)
             if create_doms:
                 print_resource(manager.create(aim_ctx, res, overwrite=True))
-        for vmm_name, cfg in vmms.iteritems():
+        for vmm_name, cfg in vmms.items():
             res = resource.VMMDomain(
                 type=vmm_types.get(
                     cfg.get('apic_vmm_type', 'openstack').lower()),
@@ -414,7 +414,7 @@ def sync_state_recover(ctx):
                 manager.update(aim_ctx, aim_res)
             except Exception as e:
                 click.echo("Failed to recover %s: %s" %
-                           (str(aim_res), e.message))
+                           (str(aim_res), str(e)))
 
 
 @manager.command(name='schema-get')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,12 +10,13 @@ hacking<0.11,>=0.10.0
 cherrypy
 coverage>=3.6
 # Needed by apicapi
-MySQL-Python
+PyMySQL>=0.7.6 # MIT License
 pyOpenSSL>=16.2.0
 python-subunit>=0.0.18
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 oslosphinx>=2.5.0 # Apache-2.0
 oslotest>=1.10.0 # Apache-2.0
+oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
 testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ install_command =
 setenv =
    VIRTUAL_ENV={envdir}
    OS_TEST_TIMEOUT=120
+   LANG=en_US.utf8
 deps = -r{toxinidir}/test-requirements.txt
 commands = python setup.py test --slowest --testr-args='{posargs}'
 


### PR DESCRIPTION
Added Python3 compatible code.


Major changes:
----------------
In our DB model, Attributes `object_dict` and `tree` uses LargeBinary sqlalchemy datatype. LargeBinary sqlalchemy datatype needs "bytes-like" object and in Py2, string are bytes-like objects while in Py3 they aren't. So we need to store "bytes-like" object in DB objects.

Added encoding (utf-8) when adding 2 above mentioned attributes to the DB.
Added decoding when fetching these 2 attributes from the DB.

Added deep_sort() to overcome Py3 sorted() for list of nested dicts.
Added is_equal() to compare 2 list of nested dicts.

Moved encoding & decoding at "aim.db.model_base"
Added encoding & decoding at "aim.tree_manager"