### PR TITLE
Skip those duplicate SG rules

### DIFF
--- a/aim/api/tree.py
+++ b/aim/api/tree.py
@@ -61,6 +61,7 @@ class ActionLog(api_res.ResourceBase):
     CREATE = 'create'
     DELETE = 'delete'
     RESET = 'reset'
+    SKIP = 'skip'
 
     identity_attributes = t.identity(
         ('uuid', t.string(64))

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -258,6 +258,14 @@ class TestAimDBBase(BaseTestCase):
         return {type: {'attributes': attr}}
 
     @classmethod
+    def _get_example_aim_security_group_rule(cls, **kwargs):
+        example = resource.SecurityGroupRule(
+            tenant_name='t1', security_group_name='sg1',
+            security_group_subject_name='sgs1', name='rule1')
+        example.__dict__.update(kwargs)
+        return example
+
+    @classmethod
     def _get_example_aim_bd(cls, **kwargs):
         example = resource.BridgeDomain(tenant_name='test-tenant',
                                         vrf_name='default',

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -2876,31 +2876,23 @@ class TestAimToAciConverterSecurityGroupSubject(TestAimToAciConverterBase,
                   nameAlias='')]]
 
 
-def get_example_aim_security_group_rule(**kwargs):
-    example = resource.SecurityGroupRule(
-        tenant_name='t1', security_group_name='sg1',
-        security_group_subject_name='sgs1', name='rule1')
-    example.__dict__.update(kwargs)
-    return example
-
-
 class TestAimToAciConverterSecurityGroupRule(TestAimToAciConverterBase,
                                              base.TestAimDBBase):
-    sample_input = [get_example_aim_security_group_rule(),
-                    get_example_aim_security_group_rule(
+    sample_input = [base.TestAimDBBase._get_example_aim_security_group_rule(),
+                    base.TestAimDBBase._get_example_aim_security_group_rule(
                         security_group_name='sg2', ip_protocol=115,
                         from_port='80', to_port='443',
                         direction='egress', ethertype='1',
                         conn_track='normal', icmp_type='3',
                         icmp_code='0'),
-                    get_example_aim_security_group_rule(
+                    base.TestAimDBBase._get_example_aim_security_group_rule(
                         security_group_name='sg3', ip_protocol=1,
                         from_port='80', to_port='443',
                         remote_ips=['10.0.1.0/24', '192.168.0.0/24'],
                         direction='egress', ethertype='1',
                         conn_track='normal', icmp_type='255',
                         icmp_code='0xffff'),
-                    get_example_aim_security_group_rule(
+                    base.TestAimDBBase._get_example_aim_security_group_rule(
                         security_group_name='sg4', ip_protocol=6,
                         from_port='80', to_port='443',
                         direction='egress', ethertype='2',


### PR DESCRIPTION
We still need to make sure those skipped action logs
got deleted at the end though. This patch will improve
the action logs process time considerably especially
for those SG rules with huge remote_ips list.