### PR TITLE
Code to enable netflow functionality in openstack setups

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -1042,6 +1042,12 @@ resource_map = {
         'resource': resource.EndpointGroup,
         'converter': qos_rs_req,
     }],
+    'vmmVSwitchPolicyCont': [{
+        'resource': resource.VmmVswitchPolicyGroup,
+    }],
+    'vmmRsVswitchExporterPol': [{
+        'resource': resource.VmmRelationToExporterPol,
+    }],
 }
 
 resource_map.update(service_graph.resource_map)

--- a/aim/aim_manager.py
+++ b/aim/aim_manager.py
@@ -114,6 +114,8 @@ class AimManager(object):
                      api_res.NetflowVMMExporterPol,
                      api_res.QosRequirement,
                      api_res.QosDppPol,
+                     api_res.VmmVswitchPolicyGroup,
+                     api_res.VmmRelationToExporterPol,
                      api_tree.ActionLog}
 
     # Keep _db_model_map in AIM manager for backward compatibility

--- a/aim/aim_store.py
+++ b/aim/aim_store.py
@@ -283,6 +283,10 @@ class SqlAlchemyStore(AimStore):
                         models.NetflowVMMExporterPol),
                     api_res.QosRequirement: models.QosRequirement,
                     api_res.QosDppPol: models.QosDppPol,
+                    api_res.VmmVswitchPolicyGroup: (
+                        models.VmmVswitchPolicyGroup),
+                    api_res.VmmRelationToExporterPol: (
+                        models.VmmRelationToExporterPol),
                     api_tree.ActionLog: tree_model.ActionLog}
 
     resource_map = {}

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -1450,3 +1450,49 @@ class QosDppPol(AciResourceBase):
                                          'admin_st': 'enabled',
                                          'sharing_mode': 'dedicated',
                                          'monitored': False}, **kwargs)
+
+
+class VmmVswitchPolicyGroup(AciResourceBase):
+    """Resource representing VSwitch Policy Group in ACI.
+
+    Identity attributes are domain_type, domain_name.
+    """
+
+    identity_attributes = t.identity(
+        ('domain_type', t.name),
+        ('domain_name', t.name))
+    other_attributes = t.other(
+        ('monitored', t.bool),
+        ('display_name', t.name))
+
+    _aci_mo_name = 'vmmVSwitchPolicyCont'
+    _tree_parent = VMMDomain
+
+    def __init__(self, **kwargs):
+        super(VmmVswitchPolicyGroup, self).__init__({'monitored': False},
+                                                    **kwargs)
+
+
+class VmmRelationToExporterPol(AciResourceBase):
+    """Resource representing Relationship to VMM Netflow Exporter Policy.
+
+    Identity attributes are domain_type, domain_name and tDn.
+    """
+
+    identity_attributes = t.identity(
+        ('domain_type', t.name),
+        ('domain_name', t.name),
+        ('netflow_path', t.string()))
+    other_attributes = t.other(
+        ('monitored', t.bool),
+        ('active_flow_time_out', t.integer),
+        ('idle_flow_time_out', t.integer),
+        ('sampling_rate', t.integer))
+
+    _aci_mo_name = 'vmmRsVswitchExporterPol'
+    _tree_parent = VmmVswitchPolicyGroup
+
+    def __init__(self, **kwargs):
+        super(VmmRelationToExporterPol, self).__init__(
+            {'monitored': False, 'active_flow_time_out': 60,
+             'sampling_rate': 0, 'idle_flow_time_out': 15}, **kwargs)

--- a/aim/db/migration/alembic_migrations/versions/4caed435b0cd_add_netflow.py
+++ b/aim/db/migration/alembic_migrations/versions/4caed435b0cd_add_netflow.py
@@ -29,6 +29,7 @@ depends_on = None
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import VARCHAR
 
 
 def upgrade():
@@ -57,6 +58,40 @@ def upgrade():
                   server_default='0'),
         sa.UniqueConstraint('name', name='uniq_aim_infra_identity'),
         sa.PrimaryKeyConstraint('aim_id'))
+
+    op.create_table(
+        'aim_vmm_vswitch_pol_grp',
+        sa.Column('aim_id', sa.String(64), nullable=False),
+        sa.Column('domain_type', sa.String(64), nullable=False),
+        sa.Column('domain_name', sa.String(64), nullable=False),
+        sa.Column('display_name', sa.String(256), nullable=False, default=''),
+        sa.Column('monitored', sa.Boolean, nullable=False, default=False),
+        sa.Column('epoch', sa.BigInteger(), nullable=False,
+                  server_default='0'),
+        sa.PrimaryKeyConstraint('aim_id'),
+        sa.UniqueConstraint('domain_type', 'domain_name',
+                            name='uniq_aim_vswitch_pol_grp_identity'),
+        sa.Index('idx_aim_vswitch_pol_grp_identity',
+                 'domain_type', 'domain_name'))
+
+    op.create_table(
+        'aim_vmm_reln_exporter_pol',
+        sa.Column('aim_id', sa.String(64), nullable=False),
+        sa.Column('domain_type', sa.String(64), nullable=False),
+        sa.Column('domain_name', sa.String(64), nullable=False),
+        sa.Column('netflow_path', VARCHAR(512, charset='latin1'),
+                  nullable=False),
+        sa.Column('monitored', sa.Boolean, nullable=False, default=False),
+        sa.Column('active_flow_time_out', sa.Integer),
+        sa.Column('idle_flow_time_out', sa.Integer),
+        sa.Column('sampling_rate', sa.Integer),
+        sa.Column('epoch', sa.BigInteger(), nullable=False,
+                  server_default='0'),
+        sa.PrimaryKeyConstraint('aim_id'),
+        sa.UniqueConstraint('domain_type', 'domain_name', 'netflow_path',
+                            name='uniq_aim_reln_exporter_identity'),
+        sa.Index('idx_aim_reln_exporter_identity',
+                 'domain_type', 'domain_name', 'netflow_path'))
 
 
 def downgrade():

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -104,6 +104,36 @@ class NetflowVMMExporterPol(model_base.Base, model_base.HasDisplayName,
     ver = sa.Column(sa.String(16))
 
 
+class VmmVswitchPolicyGroup(model_base.Base, model_base.AttributeMixin,
+                            model_base.HasAimId, model_base.IsMonitored,
+                            model_base.HasDisplayName):
+    """DB model for VSwitch Policy Group."""
+    __tablename__ = 'aim_vmm_vswitch_pol_grp'
+    __table_args__ = (
+        model_base.uniq_column(__tablename__, 'domain_type', 'domain_name') +
+        model_base.to_tuple(model_base.Base.__table_args__))
+
+    domain_name = model_base.name_column(nullable=False)
+    domain_type = model_base.name_column(nullable=False)
+
+
+class VmmRelationToExporterPol(model_base.Base, model_base.AttributeMixin,
+                               model_base.HasAimId, model_base.IsMonitored):
+    """DB model for Vmm Relation to Exporter Pol."""
+    __tablename__ = 'aim_vmm_reln_exporter_pol'
+    __table_args__ = (
+        model_base.uniq_column(__tablename__, 'domain_type', 'domain_name',
+                               'netflow_path') +
+        model_base.to_tuple(model_base.Base.__table_args__))
+
+    domain_name = model_base.name_column(nullable=False)
+    domain_type = model_base.name_column(nullable=False)
+    netflow_path = sa.Column(VARCHAR(512, charset='latin1'), nullable=False)
+    active_flow_time_out = sa.Column(sa.Integer)
+    idle_flow_time_out = sa.Column(sa.Integer)
+    sampling_rate = sa.Column(sa.Integer)
+
+
 class Subnet(model_base.Base, model_base.HasAimId,
              model_base.HasDisplayName,
              model_base.HasTenantName,

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -322,6 +322,48 @@ class TestAimDBBase(BaseTestCase):
         return example_netflow
 
     @classmethod
+    def _get_example_aim_vswitch_policy_grp(cls, **kwargs):
+        example = resource.VmmVswitchPolicyGroup(domain_type='OpenStack',
+                                                 domain_name='osd13-fab20')
+        example.__dict__.update(kwargs)
+        return example
+
+    @classmethod
+    def _get_example_aci_vswitch_policy_grp(cls, **kwargs):
+        example_vs_pol_grp = {
+            "vmmVSwitchPolicyCont": {
+                "attributes": {
+                    "dn": "uni/vmmp-OpenStack/dom-osd13-fab20/vswitchpolcont",
+                    "ownerKey": "", "ownerTag": ""}}}
+        example_vs_pol_grp['vmmVSwitchPolicyCont']['attributes'].update(kwargs)
+        return example_vs_pol_grp
+
+    @classmethod
+    def _get_example_aim_reln_netflow(cls, **kwargs):
+        example = resource.VmmRelationToExporterPol(domain_type='OpenStack',
+                                                    domain_name='osd13-fab20',
+                                                    netflow_path='uni/infra/'
+                                                    'vmmexporterpol-test',
+                                                    active_flow_time_out=90,
+                                                    idle_flow_time_out=15,
+                                                    sampling_rate=0)
+        example.__dict__.update(kwargs)
+        return example
+
+    @classmethod
+    def _get_example_aci_reln_netflow(cls, **kwargs):
+        example_reln = {
+            "vmmRsVswitchExporterPol": {
+                "attributes": {
+                    "dn": "uni/vmmp-OpenStack/dom-osd13-fab20/vswitchpolcont/"
+                          "rsvswitchExporterPol-[uni/infra/vmmexporterpol-"
+                          "test]",
+                    "activeFlowTimeOut": 90, "idleFlowTimeOut": 15,
+                    "samplingRate": 0, "ownerKey": "", "ownerTag": ""}}}
+        example_reln['vmmRsVswitchExporterPol']['attributes'].update(kwargs)
+        return example_reln
+
+    @classmethod
     def _get_example_aci_rs_ctx(cls, **kwargs):
         example_rsctx = {
             "fvRsCtx": {

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -238,6 +238,49 @@ class TestAciToAimConverterNetflow(TestAciToAimConverterBase,
                                        ver='v5')]
 
 
+class TestAciToAimConverterVmmVswitchPolicyGroup(TestAciToAimConverterBase,
+                                                 base.TestAimDBBase):
+    resource_type = resource.VmmVswitchPolicyGroup
+    reverse_map_output = [
+        {'resource': 'vmmVSwitchPolicyCont',
+         'exceptions': {}}]
+    sample_input = [base.TestAimDBBase._get_example_aci_vswitch_policy_grp(),
+                    base.TestAimDBBase._get_example_aci_vswitch_policy_grp(
+                        dn='uni/vmmp-OpenStack1/dom-osd13-fab2/'
+                           'vswitchpolcont')]
+    sample_output = [
+        resource.VmmVswitchPolicyGroup(
+            domain_type='OpenStack', domain_name='osd13-fab20'),
+        resource.VmmVswitchPolicyGroup(
+            domain_type='OpenStack1', domain_name='osd13-fab2')
+    ]
+
+
+class TestAciToAimConverterVmmRelationToExporterPol(TestAciToAimConverterBase,
+                                                    base.TestAimDBBase):
+    resource_type = resource.VmmRelationToExporterPol
+    reverse_map_output = [
+        {'resource': 'vmmRsVswitchExporterPol',
+         'exceptions': {}}]
+    sample_input = [base.TestAimDBBase._get_example_aci_reln_netflow(),
+                    base.TestAimDBBase._get_example_aci_reln_netflow(
+                        dn='uni/vmmp-OpenStack1/dom-osd13-fab2/vswitchpolcont'
+                           '/rsvswitchExporterPol-[uni/infra/vmmexporterpol-'
+                           'test2]',
+                        activeFlowTimeOut=120, idleFlowTimeOut=10,
+                        samplingRate=5)]
+    sample_output = [
+        resource.VmmRelationToExporterPol(
+            domain_type='OpenStack', domain_name='osd13-fab20',
+            netflow_path='uni/infra/vmmexporterpol-test',
+            active_flow_time_out=90, idle_flow_time_out=15, sampling_rate=0),
+        resource.VmmRelationToExporterPol(
+            domain_type='OpenStack1', domain_name='osd13-fab2',
+            netflow_path='uni/infra/vmmexporterpol-test2',
+            active_flow_time_out=120, idle_flow_time_out=10, sampling_rate=5)
+    ]
+
+
 class TestAciToAimConverterVRF(TestAciToAimConverterBase, base.TestAimDBBase):
     resource_type = resource.VRF
     reverse_map_output = [{
@@ -3985,6 +4028,44 @@ class TestAimToAciConverterNetflow(TestAimToAciConverterBase,
                   srcAddr='1.2.2.3',
                   ver='v5',
                   nameAlias='')]
+    ]
+
+
+class TestAimToAciConverterVmmVswitchPolicyGroup(TestAimToAciConverterBase,
+                                                 base.TestAimDBBase):
+    sample_input = [
+        base.TestAimDBBase._get_example_aim_vswitch_policy_grp(),
+        base.TestAimDBBase._get_example_aim_vswitch_policy_grp(
+            domain_type='OpenStack1', domain_name='osd13-fab2')]
+
+    sample_output = [
+        [_aci_obj('vmmVSwitchPolicyCont',
+                  dn=('uni/vmmp-OpenStack/dom-osd13-fab20/vswitchpolcont'),
+                  nameAlias='')],
+        [_aci_obj('vmmVSwitchPolicyCont',
+                  dn=('uni/vmmp-OpenStack1/dom-osd13-fab2/vswitchpolcont'),
+                  nameAlias='')]
+    ]
+
+
+class TestAimToAciConverterVmmRelationToExporterPol(TestAimToAciConverterBase,
+                                                    base.TestAimDBBase):
+    sample_input = [
+        base.TestAimDBBase._get_example_aim_reln_netflow(),
+        base.TestAimDBBase._get_example_aim_reln_netflow(
+            domain_type='OpenStack1', domain_name='osd13-fab2',
+            netflow_path='uni/infra/vmmexporterpol-test2',
+            active_flow_time_out=120, idle_flow_time_out=10, sampling_rate=5)]
+
+    sample_output = [
+        [_aci_obj('vmmRsVswitchExporterPol',
+                  dn=('uni/vmmp-OpenStack/dom-osd13-fab20/vswitchpolcont/'
+                      'rsvswitchExporterPol-[uni/infra/vmmexporterpol-test]'),
+                  activeFlowTimeOut=90, idleFlowTimeOut=15, samplingRate=0)],
+        [_aci_obj('vmmRsVswitchExporterPol',
+                  dn=('uni/vmmp-OpenStack1/dom-osd13-fab2/vswitchpolcont/'
+                      'rsvswitchExporterPol-[uni/infra/vmmexporterpol-test2]'),
+                  activeFlowTimeOut=120, idleFlowTimeOut=10, samplingRate=5)]
     ]
 
 

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -748,6 +748,52 @@ class TestNetflowVMMExporterPolMixin(object):
     res_command = 'netflow-vmm-exporter-pol'
 
 
+class TestVmmVswitchPolicyGroupMixin(object):
+    resource_class = resource.VmmVswitchPolicyGroup
+    resource_root_type = resource.VMMPolicy._aci_mo_name
+    prereq_objects = [resource.VMMPolicy(type='OpenStack'),
+                      resource.VMMDomain(type='OpenStack',
+                                         name='osd13-fab20')]
+    test_identity_attributes = {'domain_type': 'OpenStack',
+                                'domain_name': 'osd13-fab20'}
+    test_required_attributes = {'domain_type': 'OpenStack',
+                                'domain_name': 'osd13-fab20'}
+    test_search_attributes = {'domain_name': 'osd13-fab20'}
+    test_update_attributes = {'display_name': 'OpenStack-netflow'}
+    test_default_values = {'monitored': False}
+    test_dn = 'uni/vmmp-OpenStack/dom-osd13-fab20/vswitchpolcont'
+    res_command = 'vmm-vswitch-policy-group'
+
+
+class TestVmmRelationToExporterPolMixin(object):
+    resource_class = resource.VmmRelationToExporterPol
+    resource_root_type = resource.VMMPolicy._aci_mo_name
+    prereq_objects = [resource.VMMPolicy(type='OpenStack'),
+                      resource.VMMDomain(type='OpenStack',
+                                         name='osd13-fab20')]
+    test_identity_attributes = {'domain_type': 'OpenStack',
+                                'domain_name': 'osd13-fab20',
+                                'netflow_path': 'uni/infra/'
+                                                'vmmexporterpol-test'}
+    test_required_attributes = {'domain_type': 'OpenStack',
+                                'domain_name': 'osd13-fab20',
+                                'netflow_path': 'uni/infra/'
+                                                'vmmexporterpol-test',
+                                'active_flow_time_out': 90,
+                                'idle_flow_time_out': 15,
+                                'sampling_rate': 0}
+    test_search_attributes = {'domain_name': 'osd13-fab20'}
+    test_update_attributes = {'active_flow_time_out': 120,
+                              'idle_flow_time_out': 10,
+                              'sampling_rate': 5}
+    test_default_values = {'active_flow_time_out': 60,
+                           'idle_flow_time_out': 15,
+                           'sampling_rate': 0}
+    res_command = 'vmm-relation-to-exporter-pol'
+    test_dn = ('uni/vmmp-OpenStack/dom-osd13-fab20/vswitchpolcont/'
+               'rsvswitchExporterPol-[uni/infra/vmmexporterpol-test]')
+
+
 class TestAgentMixin(object):
     resource_class = resource.Agent
     test_identity_attributes = {'id': 'myuuid'}
@@ -2260,6 +2306,16 @@ class TestInfra(TestInfraMixin, TestResourceOpsBase,
 
 
 class TestNetflowVMMExporterPol(TestNetflowVMMExporterPolMixin,
+                                TestAciResourceOpsBase, base.TestAimDBBase):
+    pass
+
+
+class TestVmmRelationToExporterPol(TestVmmRelationToExporterPolMixin,
+                                   TestAciResourceOpsBase, base.TestAimDBBase):
+    pass
+
+
+class TestVmmVswitchPolicyGroup(TestVmmVswitchPolicyGroupMixin,
                                 TestAciResourceOpsBase, base.TestAimDBBase):
     pass
 

--- a/aim/tests/unit/tools/cli/test_manager.py
+++ b/aim/tests/unit/tools/cli/test_manager.py
@@ -635,6 +635,18 @@ class TestNetflowVMMExporterPol(
     pass
 
 
+class TestVmmVswitchPolicyGroup(
+        test_aim_manager.TestVmmVswitchPolicyGroupMixin,
+        TestManagerResourceOpsBase, base.TestShell):
+    pass
+
+
+class TestVmmRelationToExporterPol(
+        test_aim_manager.TestVmmRelationToExporterPolMixin,
+        TestManagerResourceOpsBase, base.TestShell):
+    pass
+
+
 class TestSubnet(test_aim_manager.TestSubnetMixin, TestManagerResourceOpsBase,
                  base.TestShell):
     pass


### PR DESCRIPTION
- Code to enable netflow functionality on opnestack setups.
- Added code to establish relationship to vmm domain.
- Tested on live fabric to make sure policies are pushed to leaf and compute nodes.