### PR TITLE
Fix AIM QoS DB

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/794ad00f3080_qos_policies.py
+++ b/aim/db/migration/alembic_migrations/versions/794ad00f3080_qos_policies.py
@@ -47,9 +47,7 @@ def upgrade():
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
                             name='uniq_aim_qos_req_identity'),
-        sa.Index('idx_aim_qos_req_identity', 'tenant_name', 'name'),
-        sa.ForeignKeyConstraint(
-            ['tenant_name'], ['aim_tenants.name'], name='fk_qos_req_tn'))
+        sa.Index('idx_aim_qos_req_identity', 'tenant_name', 'name'))
 
     op.create_table(
         'aim_qos_dpp_pol',
@@ -83,9 +81,7 @@ def upgrade():
                   server_default='0'),
         sa.PrimaryKeyConstraint('aim_id'),
         sa.UniqueConstraint('tenant_name', 'name',
-                            name='uniq_aim_qos_bw_lt_identity'),
-        sa.ForeignKeyConstraint(
-            ['tenant_name'], ['aim_tenants.name'], name='fk_qos_bw_lt_tn'))
+                            name='uniq_aim_qos_bw_lt_identity'))
 
     op.create_table(
         'aim_qos_dscp_marking',


### PR DESCRIPTION
Commit 4ce65eda8f4779c840d1a213654151c774930c80 added support for
QoS features in ACI. The DB migrations included foreign key constriants
to other tables, which aren't needed for most AIM ORM objects, since
AIM allows child objects to be configured in the DB before their parent
(except in cases where the child ORM object isn't represented as an AIM
resource, such as SecurityGroupRuleRemoteIp). Changing DB migration
scripts is permitted, provided it happens before a release is created
that includes the DB migraiton.