### PR TITLE
Add aim-aid init script

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,4 @@
+etc/aim/aim.conf /etc/aim/
 debian/aim-aid.conf /etc/init/
 debian/aim-event-service-polling.conf /etc/init/
 debian/aim-event-service-rpc.conf /etc/init/


### PR DESCRIPTION
The new packaging scripts weren't including the aim.conf file in
the right place. This patch ensures that it gets installed.