### PR TITLE
Add configurable websocket login monitor timeout

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -79,7 +79,7 @@ class WebSocketContext(object):
         self.ws_urls = collections.deque()
         self.is_session_reconnected = False
         self.monitor_runs = {'monitor_runs': float('inf')}
-        self.monitor_sleep_time = 10
+        self.monitor_sleep_time = aim_cfg.CONF.aim.websocket_monitor_sleep
         self.monitor_max_backoff = 30
         self.login_thread = None
         self.subs_thread = None

--- a/aim/config.py
+++ b/aim/config.py
@@ -73,6 +73,8 @@ agent_opts = [
                     "the orchestrator this AID agent is serving"),
     cfg.FloatOpt('aci_tenant_polling_yield', default=0.2,
                  help="how long the ACITenant yield to other processed"),
+    cfg.FloatOpt('websocket_monitor_sleep', default=10,
+                 help="how long the ACITenant yield to other processed"),
     cfg.IntOpt('max_operation_retry', default=5,
                help="How many creations/deletions are attempted by AID before "
                     "declaring failure on a specific object"),


### PR DESCRIPTION
Make the sleep timeout for websocket logins configurable. This may
be needed for installations using cert-based logins.