### PR TITLE
Fix requirements for upstream consumers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ kubernetes
 oslo.concurrency
 oslo.config
 oslo.db
-oslo.messaging<9.0
+oslo.messaging>7=.0.0
 oslo.log
 oslo.utils
 pbr>=1.6,<2.0


### PR DESCRIPTION
The group-based-policy project requires a higher version of
oslo.messaging. Specify requirements that are in line with
what's used upstream.