### PR TITLE
Fix pbr for upstream consumers

### DIFF
--- a/aim/tests/etc/aim.conf.test
+++ b/aim/tests/etc/aim.conf.test
@@ -1,9 +1,9 @@
 [DEFAULT]
 #debug=True
+transport_url=
 
 [database]
 connection = 'sqlite://'
-
 
 [apic]
 # Hostname:port list of APIC controllers

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,9 @@ kubernetes
 oslo.concurrency
 oslo.config
 oslo.db
-oslo.messaging>7=.0.0
+oslo.messaging>7.0.0,!=9.0.0
 oslo.log
 oslo.utils
-pbr>=1.6,<2.0
+pbr>=1.6
 semantic_version
 tabulate


### PR DESCRIPTION
Some upstream consumers require pbr newer than 2.0.