### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ kubernetes
 oslo.concurrency
 oslo.config
 oslo.db
-oslo.messaging>7.0.0,!=9.0.0
+oslo.messaging>=5.35.6,!=9.0.0
 oslo.log
 oslo.utils
 pbr>=1.6


### PR DESCRIPTION
Change oslo.messaging requirements so that AIM can be used
across multiple stable branches of upstream consumers.