### PR TITLE
Fix cert-based authentication

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -339,9 +339,14 @@ class WebSocketContext(object):
         aim_context = aim_ctx.AimContext(store=api.get_store())
         LOG.debug("Monitoring threads login and subscription")
         try:
+            if (self.private_key_file or self.cert_name):
+                threads = ((self.subs_thread, 'subscription_thread'),)
+            else:
+                threads = ((self.login_thread, 'login_thread'),
+                           (self.subs_thread, 'subscription_thread'))
+
             while flag['monitor_runs']:
-                for thd, name in [(self.login_thread, 'login_thread'),
-                                  (self.subs_thread, 'subscription_thread')]:
+                for thd, name in threads:
                     if thd and not thd.isAlive():
                         if name_to_retry[name] and name_to_retry[
                                 name].get() >= max_retries:


### PR DESCRIPTION
When using certificate-based authentication with APIC, APIC doesn't
require periodic logins to refresh authentication, as authentication
is instead managed by certificates. Password-based authentication uses
a periodic login thread in acitoolkit to maintain valid authentication
session with APIC. However, acitoolkit doesn't spawn a login thread if
certificate-based authentication is used. The AIM/AID code currently
checks to make sure that there is always a login thread present, and
if there isn't, it restarts AIM/AID. This patch fixes AIM/AID to only
check the login thread if username/password-based authentication is
used.