### PR TITLE
Avoid mysql 1.0 for py27

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,7 +10,8 @@ hacking<0.11,>=0.10.0
 cherrypy
 coverage>=3.6
 # Needed by apicapi
-PyMySQL>=0.7.6 # MIT License
+PyMySQL!=v1.0.0,>=0.7.6;python_version=='2.7' # MIT License
+PyMySQL>=0.7.6;python_version!='2.7' # MIT License
 pyOpenSSL>=16.2.0
 python-subunit>=0.0.18
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2


### PR DESCRIPTION
The mysql package 1.0 no longer supports python2.7. As a result,
use an older version only for UTs (upstream distros will still
support mysql 1.0 with python2.7).