### PR TITLE
Fix Netflow reconciliation

### DIFF
--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -1485,17 +1485,17 @@ class VmmRelationToExporterPol(AciResourceBase):
         ('netflow_path', t.string()))
     other_attributes = t.other(
         ('monitored', t.bool),
-        ('active_flow_time_out', t.integer),
-        ('idle_flow_time_out', t.integer),
-        ('sampling_rate', t.integer))
+        ('active_flow_time_out', t.string()),
+        ('idle_flow_time_out', t.string()),
+        ('sampling_rate', t.string()))
 
     _aci_mo_name = 'vmmRsVswitchExporterPol'
     _tree_parent = VmmVswitchPolicyGroup
 
     def __init__(self, **kwargs):
         super(VmmRelationToExporterPol, self).__init__(
-            {'monitored': False, 'active_flow_time_out': 60,
-             'sampling_rate': 0, 'idle_flow_time_out': 15}, **kwargs)
+            {'monitored': False, 'active_flow_time_out': '60',
+             'sampling_rate': '0', 'idle_flow_time_out': '15'}, **kwargs)
 
 
 class SpanVsourceGroup(AciResourceBase):

--- a/aim/db/migration/alembic_migrations/versions/HEAD
+++ b/aim/db/migration/alembic_migrations/versions/HEAD
@@ -1,1 +1,1 @@
-105b5f35b8fd
+ffbe2f21aa75

--- a/aim/db/migration/alembic_migrations/versions/ffbe2f21aa75_netflow_Rs_string.py
+++ b/aim/db/migration/alembic_migrations/versions/ffbe2f21aa75_netflow_Rs_string.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2021 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Use strings for ERSPAN summary resource
+Revision ID: ffbe2f21aa75
+Revises: 105b5f35b8fd
+Create date: 2021-01-24 16:56:03.236000000
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ffbe2f21aa75'
+down_revision = '105b5f35b8fd'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('aim_vmm_reln_exporter_pol') as batch_op:
+        batch_op.alter_column(
+            "active_flow_time_out", existing_type=sa.Integer,
+            type_=sa.String(16),
+            existing_nullable=False,
+            nullable=False)
+        batch_op.alter_column(
+            "idle_flow_time_out", existing_type=sa.Integer,
+            type_=sa.String(16),
+            existing_nullable=False,
+            nullable=False)
+        batch_op.alter_column(
+            "sampling_rate", existing_type=sa.Integer,
+            type_=sa.String(16),
+            existing_nullable=False,
+            nullable=False)
+
+
+def downgrade():
+    pass

--- a/aim/db/models.py
+++ b/aim/db/models.py
@@ -129,9 +129,9 @@ class VmmRelationToExporterPol(model_base.Base, model_base.AttributeMixin,
     domain_name = model_base.name_column(nullable=False)
     domain_type = model_base.name_column(nullable=False)
     netflow_path = sa.Column(VARCHAR(512, charset='latin1'), nullable=False)
-    active_flow_time_out = sa.Column(sa.Integer)
-    idle_flow_time_out = sa.Column(sa.Integer)
-    sampling_rate = sa.Column(sa.Integer)
+    active_flow_time_out = sa.Column(sa.String(16))
+    idle_flow_time_out = sa.Column(sa.String(16))
+    sampling_rate = sa.Column(sa.String(16))
 
 
 class Subnet(model_base.Base, model_base.HasAimId,

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -777,16 +777,16 @@ class TestVmmRelationToExporterPolMixin(object):
                                 'domain_name': 'osd13-fab20',
                                 'netflow_path': 'uni/infra/'
                                                 'vmmexporterpol-test',
-                                'active_flow_time_out': 90,
-                                'idle_flow_time_out': 15,
-                                'sampling_rate': 0}
+                                'active_flow_time_out': '90',
+                                'idle_flow_time_out': '15',
+                                'sampling_rate': '0'}
     test_search_attributes = {'domain_name': 'osd13-fab20'}
-    test_update_attributes = {'active_flow_time_out': 120,
-                              'idle_flow_time_out': 10,
-                              'sampling_rate': 5}
-    test_default_values = {'active_flow_time_out': 60,
-                           'idle_flow_time_out': 15,
-                           'sampling_rate': 0}
+    test_update_attributes = {'active_flow_time_out': '120',
+                              'idle_flow_time_out': '10',
+                              'sampling_rate': '5'}
+    test_default_values = {'active_flow_time_out': '60',
+                           'idle_flow_time_out': '15',
+                           'sampling_rate': '0'}
     res_command = 'vmm-relation-to-exporter-pol'
     test_dn = ('uni/vmmp-OpenStack/dom-osd13-fab20/vswitchpolcont/'
                'rsvswitchExporterPol-[uni/infra/vmmexporterpol-test]')


### PR DESCRIPTION
The hash tree comparison fails due to integer types being converted to string values when creating the APIC-side hash tree. These string values result in different hashes in the hash tree for those resources, and therefore AID never reaches sync. This patch converts the integer values used by Netflow Rs object to strings.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com