### PR TITLE
Fix debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: http://github.com/noironetworks/aci-integration-module
 Package: aci-integration-module
 Architecture: all
 Depends: python-click-cli (>=3.3) | python-click (>=6.2), python-oslo.config (>=1.4),
-         ${misc:Depends}, alembic, acitoolkit, apicapi, python-click, python-jsonschema,
+         ${misc:Depends}, alembic, acitoolkit, python-apicapi, python-click, python-jsonschema,
          python-pbr, python-tabulate, python-semantic-version
 Description: Python2.7 library for programming ACI
  Library for programming ACI 


### PR DESCRIPTION
Commit 4da3a22417ea6f15ac823f8e3abf7275269bb2ab removed the
"python-" prefix from the python-apicapi dependency, which is
incorrect. This reverts that chnage.