### PR TITLE
Fix python36 Unit Tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,7 @@
 hacking<0.11,>=0.10.0
 
 cherrypy
+click<=7.1.2
 coverage>=3.6
 # Needed by apicapi
 PyMySQL!=v1.0.0,>=0.7.6;python_version=='2.7' # MIT License


### PR DESCRIPTION
The py36 UTs were failing Travis CI, due to an issue with arguments
in the newer version of python-click. This pins python-click to the
older version. At some point, we'll need a fix for the issue with the
arguments.