### PR TITLE
Pin oslo.db for python3

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,6 +22,7 @@ sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 oslosphinx>=2.5.0 # Apache-2.0
 oslotest>=1.10.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
+oslo.db<=10.0.0 ;python_version!='2.7' # MIT License
 testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=1.4.0


### PR DESCRIPTION
With the newer package of oslo.db (11.0.0), running the DB migration
results in the following exception:

    TypeError: 'int' object is not iterable

Pin oslo.db for now, until we can find out why the newer version
breaks it.