### PR TITLE
Remove use of with_lockmode

### DIFF
--- a/aim/aim_store.py
+++ b/aim/aim_store.py
@@ -369,8 +369,6 @@ class SqlAlchemyStore(AimStore):
             else:
                 args = [getattr(db_obj_type, order_by)]
             query = query.order_by(*args)
-        if lock_update:
-            query = query.with_lockmode('update')
         return query
 
     def query_statuses(self, resources):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,7 +15,6 @@ PyMySQL!=v1.0.0,>=0.7.6;python_version=='2.7' # MIT License
 PyMySQL>=0.7.6;python_version!='2.7' # MIT License
 pyOpenSSL>=16.2.0
 cryptography<=3.3.2;python_version!='2.7' # MIT License
-SQLAlchemy<=1.3.19
 decorator<=4.2.1
 python-subunit>=0.0.18
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2


### PR DESCRIPTION
The use of the now-removed with_lockmode parameter is meaningless,
since most deployments use a distributed database (e.g. Galera)
that doesn't support distributed locking.

Commit 462b1ea711c91b06bd5e8c5cfcd3e8c3a1d480e5 pinned SQLAlchemy
in order to avoid the exception that was thrown due to the fact that
the "with_lockmode" parameter was removed from newer versions.

This patch un-pins SQLAlchemy and removes the use of with_lockmode.