### PR TITLE
Set 'convert_monitored' flag to False for Security Group objects

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -1107,19 +1107,22 @@ resource_map = {
     }],
     'hostprotPol': [
         {'resource': resource.SecurityGroup,
-         'converter': hostprot_pol_converter, },
+         'converter': hostprot_pol_converter,
+         'convert_monitored': False, },
         {'resource': resource.SystemSecurityGroup,
          'converter': hostprot_pol_converter, }
     ],
     'hostprotSubj': [
         {'resource': resource.SecurityGroupSubject,
-         'converter': hostprot_subj_converter, },
+         'converter': hostprot_subj_converter,
+         'convert_monitored': False, },
         {'resource': resource.SystemSecurityGroupSubject,
          'converter': hostprot_subj_converter, }
     ],
     'hostprotRule': [
         {'resource': resource.SecurityGroupRule,
          'converter': hostprot_rule_converter,
+         'convert_monitored': False,
          'skip': ['remote_ips', 'remote_group_id'],
          'exceptions': {
              'protocol': {'other': 'ip_protocol',
@@ -1153,7 +1156,8 @@ resource_map = {
     ],
     'hostprotRemoteIp': [
         {'resource': resource.SecurityGroupRule,
-         'converter': hostprot_remoteIp_converter, },
+         'converter': hostprot_remoteIp_converter,
+         'convert_monitored': False, },
         {'resource': resource.SystemSecurityGroupRule,
          'converter': hostprot_remoteIp_converter, }
     ],

--- a/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
@@ -986,6 +986,10 @@ class TestAciTenant(base.TestAimDBBase, TestAciClientMixin):
     def test_aci_types_not_convertible_if_monitored(self):
         self.assertEqual({'fvRsProv': ['l3extInstP'],
                           'fvRsCons': ['l3extInstP'],
+                          'hostprotPol': ['hostprotPol'],
+                          'hostprotRemoteIp': ['hostprotRule'],
+                          'hostprotRule': ['hostprotRule'],
+                          'hostprotSubj': ['hostprotSubj'],
                           'infraRsSpanVSrcGrp': ['infraAccBndlGrp'],
                           'infraRsSpanVDestGrp': ['infraAccBndlGrp']},
                          aci_tenant.ACI_TYPES_NOT_CONVERT_IF_MONITOR)

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1241,9 +1241,11 @@ class TestAciToAimConverterSecurityGroupRule(TestAciToAimConverterBase,
                           'converter': converter.ethertype}},
          'skip': ['remoteIps', 'remoteGroupId'],
          'converter': converter.hostprot_rule_converter,
+         'convert_monitored': False,
          'resource': 'hostprotRule'},
         {'exceptions': {},
          'converter': converter.hostprot_remoteIp_converter,
+         'convert_monitored': False,
          'resource': 'hostprotRemoteIp'}]
     sample_input = [get_example_aci_security_group_rule(),
                     get_example_aci_security_group_rule(


### PR DESCRIPTION
Set 'convert_monitored' flag to False for Security Group objects
so that they don't show up in the Hash Trees for AIM.