### PR TITLE
Prevent the copy of the empty state when the tenant isn't "warm"

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -538,6 +538,8 @@ class AciUniverse(base.HashTreeStoredUniverse):
             with utils.get_rlock(lcon.ACI_TREE_LOCK_NAME_PREFIX + tenant):
                 if serving_tenants[tenant].is_warm():
                     new_state[tenant] = self._get_state_copy(tenant)
+                else:
+                    new_state[tenant] = self._state[tenant]
         self._state = new_state
 
     def reset(self, context, tenants):

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -119,6 +119,14 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
             self.assertTrue(tenant in self.universe.state)
             self.assertTrue(isinstance(self.universe.state[tenant],
                                        structured_tree.StructuredHashTree))
+            # Set the warm flag to False for tenants
+            self.universe.serving_tenants[tenant].is_warm = mock.Mock(
+                return_value=False)
+        self.universe.observe(self.ctx)
+        for tenant in tenant_list:
+            self.assertTrue(tenant in self.universe.state)
+            self.assertTrue(isinstance(self.universe.state[tenant],
+                                       structured_tree.StructuredHashTree))
 
     def test_serve_exception(self):
         tenant_list = ['tn-%s' % x for x in range(10)]


### PR DESCRIPTION
Add condition to prevent the copy of the empty state
when the tenant isn't "warm".