### PR TITLE
Restart if tenant manager objects are orphaned

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -517,10 +517,10 @@ class AciUniverse(base.HashTreeStoredUniverse):
                     serving_tenants[added].start()
         except Exception as e:
             LOG.error(traceback.format_exc())
-            LOG.error('Failed to serve new tenants %s' % tenants)
-            # Rollback served tenants
-            serving_tenants = serving_tenant_copy
-            raise e
+            # There can be orphaned tenant manager objects, If there is a
+            # failure in serve method. Restart the process
+            utils.perform_harakiri(LOG,
+                                   "Error in serve. Reset the tenants")
 
     def tenant_creation_failed(self, aim_object, reason='unknown',
                                error=errors.UNKNOWN):

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -125,18 +125,10 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         self.universe.serve(self.ctx, tenant_list)
         # Remove some tenants
         tenant_list_new = tenant_list[5:]
-        old = self.universe.serving_tenants['tn-9'].is_dead
-        self.universe.serving_tenants['tn-9'].is_dead = mock.Mock(
-            side_effect=KeyError)
-        self.assertRaises(KeyError, self.universe.serve, self.ctx,
-                          tenant_list_new)
-        self.universe.serving_tenants['tn-9'].is_dead = old
+        self.universe.serve(self.ctx, tenant_list_new)
         # List of serving tenant back to the initial one
-        self.assertEqual(set(tenant_list),
+        self.assertEqual(set(tenant_list_new),
                          set(self.universe.serving_tenants.keys()))
-        # Thread that were once removed are now dead
-        for tenant in tenant_list[:5]:
-            self.assertTrue(self.universe.serving_tenants[tenant].is_dead())
         # Others are not
         for tenant in tenant_list[5:]:
             self.assertFalse(self.universe.serving_tenants[tenant].is_dead())


### PR DESCRIPTION
If there are failures when we 'serve' the tenants in different universes, some orphaned tenant manager objects can exist. To avoid this situation, we restart the process on failure