### PR TITLE
Fix websocket subscription refreshes

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -315,6 +315,9 @@ class WebSocketContext(object):
                                                 code=resp.status_code,
                                                 text=resp.text)
 
+    def refresh_subscriptions(self, url=None):
+        self.session.refresh_subscriptions(url=url)
+
     def get_event_data(self, urls):
         result = []
         for url in urls:

--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -47,7 +47,8 @@ CHILDREN_MOS_UNI = None
 CHILDREN_MOS_TOPOLOGY = None
 SUPPORTS_ANNOTATIONS = None
 RESET_INTERVAL = 3600
-DEFAULT_WS_TO = '900'
+DEFAULT_WS_TO = '60'
+BASELINE_WS_TO = '900'
 
 
 class ScheduledReset(Exception):
@@ -142,7 +143,7 @@ class Root(acitoolkit.BaseACIObject):
             ws_subscription_to=ws_subscription_to)
 
     def _get_instance_subscription_urls(self,
-                                        ws_subscription_to=DEFAULT_WS_TO):
+                                        ws_subscription_to=BASELINE_WS_TO):
         if not self.dn.startswith('topology'):
             url = ('/api/node/mo/{}.json?query-target=subtree&'
                    'rsp-prop-include=config-only&rsp-subtree-include=faults&'
@@ -311,10 +312,13 @@ class AciTenantManager(utils.AIMThread):
         self.tenant_name = tenant_name
         children_mos = get_children_mos(self.aci_session, self.tenant_name)
         ws_subscription_to = self.apic_config.get_option(
-            'websocket_subscription_timeout', 'aim') or DEFAULT_WS_TO
+            'websocket_subscription_timeout', 'aim') or BASELINE_WS_TO
+        if int(ws_subscription_to) < int(DEFAULT_WS_TO):
+            ws_subscription_to = DEFAULT_WS_TO
+        self.ws_subscription_to = ws_subscription_to
         self.tenant = Root(self.tenant_name, filtered_children=children_mos,
                            rn=self.tenant_name,
-                           ws_subscription_to=ws_subscription_to)
+                           ws_subscription_to=self.ws_subscription_to)
         self._state = structured_tree.StructuredHashTree()
         self._operational_state = structured_tree.StructuredHashTree()
         self._monitored_state = structured_tree.StructuredHashTree()
@@ -408,6 +412,10 @@ class AciTenantManager(utils.AIMThread):
                 start = time.time()
                 if start > self.scheduled_reset:
                     raise ScheduledReset()
+                if start > self.refresh_time:
+                    self.ws_context.refresh_subscriptions(
+                        urls=self.tenant.urls)
+                    self.refresh_time = self._schedule_websocket_refresh()
                 self._event_loop()
                 curr_time = time.time() - start
                 if abs(curr_time - last_time) > epsilon:
@@ -647,6 +655,10 @@ class AciTenantManager(utils.AIMThread):
         self.scheduled_reset = utils.schedule_next_event(RESET_INTERVAL, 0.2)
         self._event_loop()
         self._warm = True
+        self.refresh_time = self._schedule_websocket_refresh()
+
+    def _schedule_websocket_refresh(self):
+        return utils.get_time() + int(self.ws_subscription_to) / 2
 
     def _event_to_tree(self, events):
         """Parse the event and push it into the tree

--- a/aim/config.py
+++ b/aim/config.py
@@ -106,7 +106,7 @@ agent_opts = [
                      "be sent in websocket subscriptions. If it is set to 0, "
                      "then a timeout will not be sent in websocket "
                      "subscriptions, and APIC will use it's default timeout "
-                     "of 80 seconds. If set to a non-zero value, then the "
+                     "of 60 seconds. If set to a non-zero value, then the "
                      "timeout value will be provided when AID subscribes to "
                      "a URL on APIC. NOTE: the subscription timeout is not "
                      "supported by APIC versions before 3.2(3), so this "


### PR DESCRIPTION
AIM uses the websocket refresh subscription mechanism implemented
in acitoolkit. However, it uses a hard-coded refresh interval (30
seconds), with all subscriptions refreshed at the same time. This
results in bursts of subscription refreshes, and causes excessive
load on the APIC controller when there is a large number of
roots/tenants. The subscription refresh API in acitoolkit was
extended to support passing in URLs for refresh, which allows each
AciTenantManager object to handle their own refreshes.

This patch also ensures that the refresh interval isn't set to
lower than the default for APIC (60 seconds).