### PR TITLE
Fix voluptuous

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -26,3 +26,4 @@ testscenarios>=0.4
 testtools>=1.4.0
 mock
 tabulate>=0.7.5
+voluptuous!=0.13.0


### PR DESCRIPTION
The release of voluptuous 0.13.0 results in the following
exception during package dependency resolution:

      File "./voluptuous/validators.py", line 7, in <module>
        from enum import Enum
    ImportError: No module named enum

This patch avoids that released version.