### PR TITLE
Fix external network resource APIs

### DIFF
--- a/aim/db/migration/alembic_migrations/versions/7b8a71bee019_ext_net_contracts.py
+++ b/aim/db/migration/alembic_migrations/versions/7b8a71bee019_ext_net_contracts.py
@@ -43,6 +43,10 @@ def upgrade():
         sa.Column('monitored', sa.Boolean, nullable=False, default=False),
         sa.Column('epoch', sa.BigInteger(), nullable=False,
                   server_default='0'),
+        sa.UniqueConstraint('tenant_name', 'l3out_name', 'ext_net_name',
+                            'name', name='uniq_aim_ext_net_pcon_identity'),
+        sa.Index('idx_aim_ext_net_pcon_identity',
+                 'tenant_name', 'l3out_name', 'ext_net_name', 'name'),
         sa.PrimaryKeyConstraint('aim_id'))
 
     op.create_table(
@@ -55,6 +59,10 @@ def upgrade():
         sa.Column('monitored', sa.Boolean, nullable=False, default=False),
         sa.Column('epoch', sa.BigInteger(), nullable=False,
                   server_default='0'),
+        sa.UniqueConstraint('tenant_name', 'l3out_name', 'ext_net_name',
+                            'name', name='uniq_aim_ext_net_ccon_identity'),
+        sa.Index('idx_aim_ext_net_ccon_identity',
+                 'tenant_name', 'l3out_name', 'ext_net_name', 'name'),
         sa.PrimaryKeyConstraint('aim_id'))
 
     # Migrate the data to the new tables


### PR DESCRIPTION
Previous patches broke the external network resource CRUD APIs.
For example, creating a new resource was failing to correctly
check for existing contracts. This patch fixes those bugs.