### PR TITLE
Fix for py37

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,7 @@ coverage>=3.6
 # Needed by apicapi
 PyMySQL!=v1.0.0,>=0.7.6;python_version=='2.7' # MIT License
 PyMySQL>=0.7.6;python_version!='2.7' # MIT License
-pyOpenSSL>=16.2.0
+pyOpenSSL>=16.2.0,<=22.0.0
 cryptography<=3.3.2;python_version!='2.7' # MIT License
 bcrypt<4.0.0;python_version!='2.7' # MIT License
 decorator<=4.2.1


### PR DESCRIPTION
There were compatibility issues between newer versions of OpenSSL for py37. Pin SSL for py37 until we can figure out the issue.