### PR TITLE
Fix Travis CI gate

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,6 +14,7 @@ coverage>=3.6
 PyMySQL!=v1.0.0,>=0.7.6;python_version=='2.7' # MIT License
 PyMySQL>=0.7.6;python_version!='2.7' # MIT License
 pyOpenSSL>=16.2.0,<=22.0.0
+greenlet<=1.1.3
 cryptography<=3.3.2;python_version!='2.7' # MIT License
 bcrypt<4.0.0;python_version!='2.7' # MIT License
 decorator<=4.2.1


### PR DESCRIPTION
A new version of greenlet caused the Travis CI gate to fail, due to it trying to rebuild the greenlet library. Pin the version of greenlet for now.