### PR TITLE
Add missing configuration option

### DIFF
--- a/aim/tools/cli/groups/aimcli.py
+++ b/aim/tools/cli/groups/aimcli.py
@@ -26,6 +26,8 @@ DEFAULT_FORMAT = 'tables'
 global_opts = [
     config.cfg.StrOpt('apic_system_id',
                       help="Prefix for APIC domain/names/profiles created"),
+    config.cfg.IntOpt('apic_system_id_length', default=16,
+                      help=("Maximum lengh for APIC system ID.")),
 ]
 config.CONF.register_opts(global_opts)
 curr_format = DEFAULT_FORMAT


### PR DESCRIPTION
The apic_system_id_length option was referenced in commit e123105961b8244581c23d2cc19c7ff9bd43e534, but was never defined. This patch adds the definition.