### PR TITLE
Fix passing paramete to aimctl

### DIFF
--- a/aim/tools/cli/commands/infra.py
+++ b/aim/tools/cli/commands/infra.py
@@ -40,9 +40,9 @@ def get_apic_manager():
     db = infra_model.HostLinkManager(aim_ctx, manager)
     apic_system_id = config.CONF.apic_system_id
     apic_system_id_length = config.CONF.apic_system_id_length
-    return apic_manager.APICManager(db, logging, network_config, apic_config,
-                                    None, None, apic_system_id,
-                                    apic_system_id_length)
+    return apic_manager.APICManager(
+        db, logging, network_config, apic_config, None, None,
+        apic_system_id, apic_system_id_length=apic_system_id_length)
 
 
 @aimcli.aim.group(name='infra')


### PR DESCRIPTION
Using a positional instead of the named kwargs results in passing incorrect values when creating the manager. This patch switches to use the named kwarg.