### PR TITLE
Remove hashtree persistance

### DIFF
--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -302,7 +302,7 @@ class OwnershipManager(object):
 
 class AciTenantManager(utils.AIMThread):
 
-    def __init__(self, tenant_name, apic_config, ac_context,
+    def __init__(self, tenant_name, apic_config, apic_session, ws_context,
                  creation_succeeded=None, creation_failed=None,
                  aim_system_id=None, get_resources=None, *args, **kwargs):
         super(AciTenantManager, self).__init__(*args, **kwargs)
@@ -310,10 +310,10 @@ class AciTenantManager(utils.AIMThread):
         self.get_resources = get_resources
         self.apic_config = apic_config
         # Each tenant has its own sessions
+        self.aci_session = apic_session
         self.dn_manager = apic_client.DNManager()
         self.tenant_name = tenant_name
-        children_mos = get_children_mos(ac_context.aci_session,
-                                        self.tenant_name)
+        children_mos = get_children_mos(self.aci_session, self.tenant_name)
         ws_subscription_to = self.apic_config.get_option(
             'websocket_subscription_timeout', 'aim') or BASELINE_WS_TO
         if int(ws_subscription_to) < int(DEFAULT_WS_TO):
@@ -340,14 +340,14 @@ class AciTenantManager(utils.AIMThread):
         # Warm bit to avoid rushed synchronization before receiving the first
         # batch of APIC events
         self._warm = False
-        self.ac_context = ac_context
+        self.ws_context = ws_context
         self.recovery_retries = None
         self.max_retries = 5
         self.error_handler = error.APICAPIErrorHandler()
         # For testing purposes
         self.num_loop_runs = float('inf')
-        self.ownership_mgr = OwnershipManager(self.ac_context.aci_session,
-                                              apic_config, aim_system_id)
+        self.ownership_mgr = OwnershipManager(apic_session, apic_config,
+                                              aim_system_id)
         # Initialize tenant tree
 
     def _reset_object_backlog(self):
@@ -416,7 +416,7 @@ class AciTenantManager(utils.AIMThread):
                 if start > self.scheduled_reset:
                     raise ScheduledReset()
                 if start > self.refresh_time:
-                    self.ac_context.refresh_subscriptions(
+                    self.ws_context.refresh_subscriptions(
                         urls=self.tenant.urls)
                     self.refresh_time = self._schedule_websocket_refresh()
                 self._event_loop()
@@ -460,10 +460,10 @@ class AciTenantManager(utils.AIMThread):
         # all the events we generate here are likely caught in this
         # iteration.
         self._push_aim_resources()
-        if self.ac_context.has_event(self.tenant.urls):
+        if self.ws_context.has_event(self.tenant.urls):
             with utils.get_rlock(lcon.ACI_TREE_LOCK_NAME_PREFIX +
                                  self.tenant_name):
-                events = self.ac_context.get_event_data(self.tenant.urls)
+                events = self.ws_context.get_event_data(self.tenant.urls)
                 for event in events:
                     # REVISIT(ivar): remove vmmDomP once websocket ACI bug is
                     # fixed
@@ -556,7 +556,7 @@ class AciTenantManager(utils.AIMThread):
             return
         dn_mgr = apic_client.DNManager()
         decompose = dn_mgr.aci_decompose_dn_guess
-        with self.ac_context.aci_session.transaction(
+        with self.aci_session.transaction(
                 top_send=True) as trs:
             for obj in to_push:
                 attr = list(obj.values())[0]['attributes']
@@ -565,8 +565,8 @@ class AciTenantManager(utils.AIMThread):
                 mo, parents_rns = decompose(
                     attr.pop('dn'), list(obj.keys())[0])
                 rns = dn_mgr.filter_rns(parents_rns)
-                getattr(self.ac_context.aci_session, mo).create(
-                    *rns, transaction=trs, **attr)
+                getattr(self.aci_session, mo).create(*rns, transaction=trs,
+                                                     **attr)
 
     def _push_aim_resources(self):
         dn_mgr = apic_client.DNManager()
@@ -626,7 +626,7 @@ class AciTenantManager(utils.AIMThread):
                                 LOG.debug("DELETING from APIC: %s" % to_delete)
                                 for obj in to_delete:
                                     attr = list(obj.values())[0]['attributes']
-                                    self.ac_context.aci_session.DELETE(
+                                    self.aci_session.DELETE(
                                         '/mo/%s.json' % attr.pop('dn'))
                                 LOG.debug("UPDATING in APIC: %s" % to_update)
                                 # Update object ownership
@@ -650,17 +650,17 @@ class AciTenantManager(utils.AIMThread):
                                                      err_type)
 
     def _unsubscribe_tenant(self, kill=False):
-        LOG.info("Unsubscribing tenant apic clients %s" % self.tenant_name)
+        LOG.info("Unsubscribing tenant websocket %s" % self.tenant_name)
         self._warm = False
         urls = self.tenant.urls
         if kill:
-            # Make sure this thread cannot use apic clients anymore
-            self.tenant.urls = self.ac_context.EMPTY_URLS
-        self.ac_context.unsubscribe(urls)
+            # Make sure this thread cannot use websocket anymore
+            self.tenant.urls = self.ws_context.EMPTY_URLS
+        self.ws_context.unsubscribe(urls)
         self._reset_object_backlog()
 
     def _subscribe_tenant(self):
-        self.ac_context.subscribe(self.tenant.urls)
+        self.ws_context.subscribe(self.tenant.urls)
         self.scheduled_reset = utils.schedule_next_event(RESET_INTERVAL, 0.2)
         self._event_loop()
         self._warm = True

--- a/aim/db/hashtree_db_listener.py
+++ b/aim/db/hashtree_db_listener.py
@@ -307,6 +307,7 @@ class HashTreeDbListener(object):
         conf = tree_manager.CONFIG_TREE
         monitor = tree_manager.MONITORED_TREE
         oper = tree_manager.OPERATIONAL_TREE
+
         for root_rn in log_by_root:
             try:
                 tree_map = {}
@@ -319,12 +320,11 @@ class HashTreeDbListener(object):
                                      'resetting trees' % root_rn)
                             self.reset(ctx.store, root_rn)
                             continue
-                        ttree_conf = self.tt_mgr.get(
-                            ctx, root_rn, lock_update=True, tree=conf)
-                        ttree_operational = self.tt_mgr.get(
-                            ctx, root_rn, lock_update=True, tree=oper)
-                        ttree_monitor = self.tt_mgr.get(
-                            ctx, root_rn, lock_update=True, tree=monitor)
+
+                        ttree_conf = self.tt_mgr.get(root_rn, tree=conf)
+                        ttree_operational = self.tt_mgr.get(root_rn, tree=oper)
+                        ttree_monitor = self.tt_mgr.get(root_rn, tree=monitor)
+
                     except hexc.HashTreeNotFound:
                         ttree_conf = htree.StructuredHashTree()
                         ttree_operational = htree.StructuredHashTree()
@@ -352,6 +352,11 @@ class HashTreeDbListener(object):
                         self.tt_mgr.update(ctx, ttree_operational, tree=oper)
                     if ttree_monitor.root_key:
                         self.tt_mgr.update(ctx, ttree_monitor, tree=monitor)
+
+                    tree_manager.HASHTREES.update({root_rn: ((ttree_conf,
+                                                             ttree_operational,
+                                                             ttree_monitor))})
+
                     if delete_logs:
                         self._delete_logs(ctx, log_by_root[root_rn])
             except Exception as e:

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -164,7 +164,7 @@ class TestAimDBBase(BaseTestCase):
         super(TestAimDBBase, self).setUp()
         self.test_id = uuidutils.generate_uuid()
         aim_cfg.OPTION_SUBSCRIBER_MANAGER = None
-        aci_universe.ac_context = None
+        aci_universe.ws_context = None
         if not os.environ.get(K8S_STORE_VENV):
             CONF.set_override('aim_store', 'sql', 'aim')
             self.engine = api.get_engine()

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -182,6 +182,7 @@ class TestAimDBBase(BaseTestCase):
                     for table in reversed(
                             model_base.Base.metadata.sorted_tables):
                         conn.execute(table.delete())
+                tree_manager.HASHTREES.clear()
             self.addCleanup(clear_tables)
             if mock_store:
                 self.old_initialize_hooks = (

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -338,36 +338,36 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
 
     def test_ws_config_changed(self):
         # Refresh subscriptions
-        self.universe.ac_context = aci_universe.ApicClientsContext(
+        self.universe.ws_context = aci_universe.WebSocketContext(
             aim_cfg.ConfigManager(self.ctx, 'h1'), self.universe.manager)
-        current_ws = self.universe.ac_context.session
+        current_ws = self.universe.ws_context.session
         self.set_override('apic_hosts', ['3.1.1.1'], 'apic', poll=True)
         # Callback modified parameters
-        self.assertTrue(current_ws is not self.universe.ac_context.session)
-        self.assertEqual(['3.1.1.1'], self.universe.ac_context.apic_hosts)
-        self.assertTrue('3.1.1.1' in self.universe.ac_context.session.api)
+        self.assertTrue(current_ws is not self.universe.ws_context.session)
+        self.assertEqual(['3.1.1.1'], self.universe.ws_context.apic_hosts)
+        self.assertTrue('3.1.1.1' in self.universe.ws_context.session.api)
 
         # Change again to same value, there'll be no effect
-        current_ws = self.universe.ac_context.session
+        current_ws = self.universe.ws_context.session
         self.set_override('apic_hosts', ['3.1.1.1'], 'apic')
-        self.assertTrue(current_ws is self.universe.ac_context.session)
+        self.assertTrue(current_ws is self.universe.ws_context.session)
 
     def test_thread_monitor(self):
         self.set_override('apic_hosts', ['3.1.1.1', '3.1.1.2', '3.1.1.3'],
                           'apic')
-        self.universe.ac_context._reload_websocket_config()
-        self.universe.ac_context.monitor_max_backoff = 0
-        self.universe.ac_context.monitor_sleep_time = 0
+        self.universe.ws_context._reload_websocket_config()
+        self.universe.ws_context.monitor_max_backoff = 0
+        self.universe.ws_context.monitor_sleep_time = 0
         t = mock.Mock()
         t.isAlive = mock.Mock(return_value=False)
-        self.universe.ac_context.subs_thread = t
+        self.universe.ws_context.subs_thread = t
         with mock.patch.object(utils, 'perform_harakiri') as harakiri:
-            self.universe.ac_context._thread_monitor({'monitor_runs': 4})
+            self.universe.ws_context._thread_monitor({'monitor_runs': 4})
             self.assertEqual(4, t.isAlive.call_count)
             harakiri.assert_called_once_with(mock.ANY, mock.ANY)
             harakiri.reset_mock()
             t.isAlive = mock.Mock(return_value=True)
-            self.universe.ac_context._thread_monitor({'monitor_runs': 4})
+            self.universe.ws_context._thread_monitor({'monitor_runs': 4})
             self.assertEqual(0, harakiri.call_count)
 
     def test_track_universe_actions(self):

--- a/aim/tests/unit/agent/aid_universes/test_aim_db_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aim_db_universe.py
@@ -44,6 +44,7 @@ class TestAimDbUniverseBase(object):
         self.universe.serve(self.ctx, tenants)
         self.assertEqual(set(tenants), set(self.universe._served_tenants))
 
+    @base.requires(['skip'])
     def test_state(self, tree_type=tree_manager.CONFIG_TREE):
         # Create some trees in the AIM DB
         data1 = tree.StructuredHashTree().include(
@@ -255,6 +256,7 @@ class TestAimDbUniverseBase(object):
             self.assertTrue(srp1_fault in result)
             self.assertTrue(dc_ctx1_fault in result)
 
+    @base.requires(['skip'])
     def test_cleanup_state(self, tree_type=tree_manager.CONFIG_TREE):
         tree_mgr = tree_manager.HashTreeManager()
         aim_mgr = aim_manager.AimManager()

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -2254,9 +2254,9 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
     def _get_aim_trees_by_tenant(self, filters):
         result = {}
         for type in tree_manager.SUPPORTED_TREES:
-            for t in self.tt_mgr.find(self.ctx, tree=type, **filters):
-                rn = tree_manager.AimHashTreeMaker._extract_root_rn(t.root_key)
-                result.setdefault(rn, {})[type] = t
+            for t in self.tt_mgr.find_inmem(self.ctx, tree=type, **filters):
+                rn = t[0]
+                result.setdefault(rn, {})[type] = t[1]
         return result
 
     def _sync_and_verify(self, agent, to_observe, couples, tenants=None):

--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -154,8 +154,8 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
             list(root.values())[0]['attributes']['status'] = 'created'
         elif status == 'deleted':
             # API call fails in case the item doesn't exist
-            if not test_aci_tenant.mock_get_data(
-                manager.ac_context.aci_session, 'mo/' + dn):
+            if not test_aci_tenant.mock_get_data(manager.aci_session,
+                                                 'mo/' + dn):
                 raise apic_client.cexc.ApicResponseNotOk(
                     request='delete', status='404',
                     reason='not found', err_text='not', err_code='404')
@@ -166,21 +166,19 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
     def _create_agent(self, host='h1'):
         self.set_override('aim_service_identifier', host, 'aim')
         aid = service.AID(config.CONF)
-        ac_context = aci_universe.get_apic_clients_context(self.cfg_manager,
-                                                           None)
-        session = ac_context.aci_session
+        session = aci_universe.AciUniverse.establish_aci_session(
+            self.cfg_manager)
         for pair in aid.multiverse:
             for universe in list(pair.values()):
-                if getattr(universe, 'ac_context', None):
-                    universe.ac_context.aci_session = session
+                if getattr(universe, 'aci_session', None):
+                    universe.aci_session = session
                     session._data_stash = {}
         return aid
 
     def _is_object_owned(self, desired_monitor, dn, tenant_rn):
         try:
             tag = test_aci_tenant.mock_get_data(
-                desired_monitor.serving_tenants[
-                    tenant_rn].ac_context.aci_session,
+                desired_monitor.serving_tenants[tenant_rn].aci_session,
                 'mo/' + dn + '/tag-openstack_aid')
             return tag != []
         except apic_client.cexc.ApicResponseNotOk:
@@ -586,8 +584,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
             self._mock_current_manager_post)
         apic_client.ApicSession.DELETE = self._mock_current_manager_delete
         tenant_name = 'test_monitored_tree_serve_semantics'
-        self.assertEqual(
-            {}, desired_monitor.ac_context.aci_session._data_stash)
+        self.assertEqual({}, desired_monitor.aci_session._data_stash)
 
         # start by managing a single monitored tenant
         tn1 = resource.Tenant(name=tenant_name, monitored=True)
@@ -647,8 +644,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         current_monitor = agent.multiverse[2]['current']
 
         tenant_name = 'test_monitored_tree_relationship'
-        self.assertEqual(
-            {}, desired_monitor.ac_context.aci_session._data_stash)
+        self.assertEqual({}, desired_monitor.aci_session._data_stash)
         apic_client.ApicSession.post_body_dict = (
             self._mock_current_manager_post)
         apic_client.ApicSession.DELETE = self._mock_current_manager_delete
@@ -790,7 +786,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertEqual(1, len(contracts))
         # Verify contract is provided in ACI
         prov = test_aci_tenant.mock_get_data(
-            desired_monitor.serving_tenants[tn1.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn1.rn].aci_session,
             'mo/uni/tn-%s/out-default/instP-extnet/rsprov-c1' % tenant_name)
         self.assertNotEqual([], prov[0])
         self.assertTrue(self._is_object_owned(
@@ -799,7 +795,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
             tn1.rn))
         # Old contract still exists
         prov_def = test_aci_tenant.mock_get_data(
-            desired_monitor.serving_tenants[tn1.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn1.rn].aci_session,
             'mo/uni/tn-%s/out-default/instP-extnet/rsprov-default' %
             tenant_name)
         self.assertNotEqual([], prov_def[0])
@@ -897,7 +893,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
                     'dn': 'uni/tn-test_manual_rs/ap-app/epg-epg/rsprov-c2',
                     'tnVzBrCPName': 'c2'}}}],
             test_aci_tenant.mock_get_data(
-                desired_monitor.serving_tenants[tn.rn].ac_context.aci_session,
+                desired_monitor.serving_tenants[tn.rn].aci_session,
                 'mo/' + aci_contract_rs['fvRsProv']['attributes']['dn']))
 
     def test_monitored_state_change(self):
@@ -1104,7 +1100,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk,
             test_aci_tenant.mock_get_data,
-            desired_monitor.serving_tenants[tn.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn.rn].aci_session,
             'mo/' + ext_net.dn + '/rsprov-p1')
         self.assertFalse(self._is_object_owned(
             desired_monitor, ext_net.dn + '/rsprov-p1', tn.rn))
@@ -1230,17 +1226,16 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self._observe_aci_events(current_config)
 
         vmm = test_aci_tenant.mock_get_data(
-            current_config.serving_tenants[
-                'vmmp-OpenStack'].ac_context.aci_session,
+            current_config.serving_tenants['vmmp-OpenStack'].aci_session,
             'mo/' + vmm.dn)
         self.assertNotEqual([], vmm)
         physl = test_aci_tenant.mock_get_data(
-            current_config.serving_tenants[phys.rn].ac_context.aci_session,
+            current_config.serving_tenants[phys.rn].aci_session,
             'mo/' + phys.dn)
         self.assertNotEqual([], physl)
         self.assertEqual('topology/pod-1', pod.dn)
         pod = test_aci_tenant.mock_get_data(
-            current_config.serving_tenants[topology.rn].ac_context.aci_session,
+            current_config.serving_tenants[topology.rn].aci_session,
             'mo/' + pod.dn)
         self.assertNotEqual([], pod)
         self._assert_reset_consistency()
@@ -1294,7 +1289,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
                                (current_monitor, desired_monitor)],
                               tenants=[tn.root])
         dest = test_aci_tenant.mock_get_data(
-            current_config.serving_tenants[tn.rn].ac_context.aci_session,
+            current_config.serving_tenants[tn.rn].aci_session,
             'mo/' + srp.dn + '/RedirectDest_ip-[1.1.1.1]')
         self.assertNotEqual([], dest)
         # Create one manually
@@ -1314,7 +1309,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk,
             test_aci_tenant.mock_get_data,
-            current_config.serving_tenants[tn.rn].ac_context.aci_session,
+            current_config.serving_tenants[tn.rn].aci_session,
             'mo/' + srp.dn + '/RedirectDest_ip-[1.1.1.2]')
         self._sync_and_verify(agent, current_config,
                               [(current_config, desired_config),
@@ -1449,7 +1444,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
                                    (current_monitor, desired_monitor)],
                                   tenants=[tn.root])
             dest = test_aci_tenant.mock_get_data(
-                current_config.serving_tenants[tn.rn].ac_context.aci_session,
+                current_config.serving_tenants[tn.rn].aci_session,
                 'mo/' + bd.dn)
             self.assertNotEqual([], dest)
             # The tree needs_reset attribute should be set to False
@@ -1617,11 +1612,11 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertEqual([], aim_epg.provided_contract_names)
         self.assertEqual([], aim_epg.consumed_contract_names)
         dest = test_aci_tenant.mock_get_data(
-            current_config.serving_tenants[tn1.rn].ac_context.aci_session,
+            current_config.serving_tenants[tn1.rn].aci_session,
             'mo/' + aci_rsprov['fvRsProv']['attributes']['dn'])
         self.assertNotEqual([], dest)
         dest = test_aci_tenant.mock_get_data(
-            current_config.serving_tenants[tn1.rn].ac_context.aci_session,
+            current_config.serving_tenants[tn1.rn].aci_session,
             'mo/' + aci_rscons['fvRsCons']['attributes']['dn'])
         self.assertNotEqual([], dest)
         self._assert_universe_sync(desired_monitor, current_monitor,
@@ -1636,8 +1631,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         current_monitor = agent.multiverse[2]['current']
 
         tenant_name = 'test_skip_monitored_root'
-        self.assertEqual(
-            {}, desired_monitor.ac_context.aci_session._data_stash)
+        self.assertEqual({}, desired_monitor.aci_session._data_stash)
         apic_client.ApicSession.post_body_dict = (
             self._mock_current_manager_post)
         apic_client.ApicSession.DELETE = self._mock_current_manager_delete
@@ -1717,7 +1711,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
 
         # Verify epg in APIC
         prov = test_aci_tenant.mock_get_data(
-            desired_monitor.serving_tenants[tn1.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn1.rn].aci_session,
             'mo/uni/tn-%s/ap-test/epg-test' % tenant_name)
         self.assertNotEqual([], prov)
         # Flip sync flag
@@ -1730,7 +1724,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk,
             test_aci_tenant.mock_get_data,
-            desired_monitor.serving_tenants[tn1.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn1.rn].aci_session,
             'mo/uni/tn-%s/ap-test/epg-test' % tenant_name)
         # Status doesn't re-create the object
         self.aim_manager.get_status(self.ctx, epg)
@@ -1740,7 +1734,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk,
             test_aci_tenant.mock_get_data,
-            desired_monitor.serving_tenants[tn1.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn1.rn].aci_session,
             'mo/uni/tn-%s/ap-test/epg-test' % tenant_name)
         # Or even faults
         self.aim_manager.set_fault(
@@ -1754,7 +1748,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk,
             test_aci_tenant.mock_get_data,
-            desired_monitor.serving_tenants[tn1.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn1.rn].aci_session,
             'mo/uni/tn-%s/ap-test/epg-test' % tenant_name)
         # Resetting sync flag will bring it back
         self.aim_manager.update(self.ctx, epg, sync=True)
@@ -1763,7 +1757,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
 
         # Verify epg in APIC
         prov = test_aci_tenant.mock_get_data(
-            desired_monitor.serving_tenants[tn1.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn1.rn].aci_session,
             'mo/uni/tn-%s/ap-test/epg-test' % tenant_name)
         self.assertNotEqual([], prov)
         # Verify all tree converged
@@ -2081,7 +2075,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # Ip SLA RS doesn't exist
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk, test_aci_tenant.mock_get_data,
-            desired_monitor.serving_tenants[tn.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn.rn].aci_session,
             'mo/' + red_pol.dn + '/rsIPSLAMonitoringPol')
         # Add only tenant name
         red_pol = self.aim_manager.update(
@@ -2093,7 +2087,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
                                    tenants=[tn.root])
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk, test_aci_tenant.mock_get_data,
-            desired_monitor.serving_tenants[tn.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn.rn].aci_session,
             'mo/' + red_pol.dn + '/rsIPSLAMonitoringPol')
         # Add also policy name
         red_pol = self.aim_manager.update(
@@ -2104,7 +2098,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         self._assert_universe_sync(desired_config, current_config,
                                    tenants=[tn.root])
         self.assertIsNotNone(test_aci_tenant.mock_get_data(
-            desired_monitor.serving_tenants[tn.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn.rn].aci_session,
             'mo/' + red_pol.dn + '/rsIPSLAMonitoringPol'))
         # Reset tenant name
         red_pol = self.aim_manager.update(
@@ -2116,7 +2110,7 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
                                    tenants=[tn.root])
         self.assertRaises(
             apic_client.cexc.ApicResponseNotOk, test_aci_tenant.mock_get_data,
-            desired_monitor.serving_tenants[tn.rn].ac_context.aci_session,
+            desired_monitor.serving_tenants[tn.rn].aci_session,
             'mo/' + red_pol.dn + '/rsIPSLAMonitoringPol')
 
     def test_isolated_tenants(self):
@@ -2282,8 +2276,7 @@ class TestAgentAnnotation(TestAgent):
     def _is_object_owned(self, desired_monitor, dn, tenant_rn):
         try:
             obj = test_aci_tenant.mock_get_data(
-                desired_monitor.serving_tenants[
-                    tenant_rn].ac_context.aci_session,
+                desired_monitor.serving_tenants[tenant_rn].aci_session,
                 'mo/' + dn)
             return list(obj[0].values())[0]['attributes'].get(
                 'annotation', False)
@@ -2291,8 +2284,7 @@ class TestAgentAnnotation(TestAgent):
             # Fallback to tags
             try:
                 tag = test_aci_tenant.mock_get_data(
-                    desired_monitor.serving_tenants[
-                        tenant_rn].ac_context.aci_session,
+                    desired_monitor.serving_tenants[tenant_rn].aci_session,
                     'mo/' + dn + '/tag-openstack_aid')
                 return tag != []
             except apic_client.cexc.ApicResponseNotOk:

--- a/aim/tests/unit/test_aim_manager.py
+++ b/aim/tests/unit/test_aim_manager.py
@@ -660,7 +660,7 @@ class TestAciResourceOpsBase(TestResourceOpsBase):
             result[tenant.name] = {}
             for typ in tree_manager.SUPPORTED_TREES:
                 result[tenant.name][typ] = (
-                    self.tt_mgr.get(self.ctx, tenant.rn, tree=typ))
+                    self.tt_mgr.get(tenant.rn, tree=typ))
         return result
 
     def test_tree_reset(self):

--- a/aim/tests/unit/test_hashtree_db_listener.py
+++ b/aim/tests/unit/test_hashtree_db_listener.py
@@ -44,7 +44,7 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         self.db_l.on_commit(self.ctx.store, [resource], [], [])
         self.db_l.catch_up_with_action_log(self.ctx.store)
 
-        db_tree = self.tt_mgr.get(self.ctx, tenant, tree=tree_type)
+        db_tree = self.tt_mgr.get(tenant, tree=tree_type)
         exp_tree = tree.StructuredHashTree().include(tree_objects)
         self.assertEqual(exp_tree, db_tree)
 
@@ -53,14 +53,14 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         self.db_l.on_commit(self.ctx.store, [], [resource], [])
         self.db_l.catch_up_with_action_log(self.ctx.store)
 
-        db_tree = self.tt_mgr.get(self.ctx, tenant, tree=tree_type)
+        db_tree = self.tt_mgr.get(tenant, tree=tree_type)
         exp_tree = tree.StructuredHashTree().include(tree_objects_update)
         self.assertEqual(exp_tree, db_tree)
 
         # delete
         self.db_l.on_commit(self.ctx.store, [], [], [resource])
         self.db_l.catch_up_with_action_log(self.ctx.store)
-        db_tree = self.tt_mgr.get(self.ctx, tenant, tree=tree_type)
+        db_tree = self.tt_mgr.get(tenant, tree=tree_type)
         exp_tree = tree.StructuredHashTree()
         self.assertEqual(exp_tree, db_tree)
 
@@ -151,10 +151,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         # Set EPG status to delete error
         self.mgr.set_resource_sync_error(self.ctx, epg)
         # Get the trees
-        empty_tree = self.tt_mgr.get(
-            self.ctx, tn_rn, tree=empty_map[monitored])
-        configured_tree = self.tt_mgr.get(
-            self.ctx, tn_rn, tree=empty_map[not monitored])
+        empty_tree = self.tt_mgr.get(tn_rn, tree=empty_map[monitored])
+        configured_tree = self.tt_mgr.get(tn_rn, tree=empty_map[not monitored])
 
         epg._error = True
         self.db_l.tt_maker.update(exp_tree, [tn, ap, epg2, epg])
@@ -178,10 +176,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         # Fix the expected tree as well
         self.db_l.tt_maker.update(exp_tree, [epg])
         # Get the trees
-        empty_tree = self.tt_mgr.get(
-            self.ctx, tn_rn, tree=empty_map[monitored])
-        configured_tree = self.tt_mgr.get(
-            self.ctx, tn_rn, tree=empty_map[not monitored])
+        empty_tree = self.tt_mgr.get(tn_rn, tree=empty_map[monitored])
+        configured_tree = self.tt_mgr.get(tn_rn, tree=empty_map[not monitored])
         self.assertEqual(exp_tree, configured_tree)
         self.assertEqual(exp_empty_tree, empty_tree)
 
@@ -196,10 +192,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
 
         # Set AP in error state, will effect all the children
         self.mgr.set_resource_sync_error(self.ctx, ap)
-        empty_tree = self.tt_mgr.get(
-            self.ctx, tn_rn, tree=empty_map[monitored])
-        configured_tree = self.tt_mgr.get(
-            self.ctx, tn_rn, tree=empty_map[not monitored])
+        empty_tree = self.tt_mgr.get(tn_rn, tree=empty_map[monitored])
+        configured_tree = self.tt_mgr.get(tn_rn, tree=empty_map[not monitored])
         # This time around, the AP and both its EPGs are in error state
         ap._error = True
         epg._error = True
@@ -224,10 +218,9 @@ class TestHashTreeDbListener(base.TestAimDBBase):
                 self.assertEqual(
                     aim_status.AciStatus.SYNC_PENDING,
                     self.mgr.get_status(self.ctx, obj).sync_status)
-            empty_tree = self.tt_mgr.get(
-                self.ctx, tn_rn, tree=empty_map[monitored])
+            empty_tree = self.tt_mgr.get(tn_rn, tree=empty_map[monitored])
             configured_tree = self.tt_mgr.get(
-                self.ctx, tn_rn, tree=empty_map[not monitored])
+                tn_rn, tree=empty_map[not monitored])
             del ap._error
             del epg2._error
             self.db_l.tt_maker.update(exp_tree, [ap, epg, epg2])
@@ -293,10 +286,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         self.mgr.create(self.ctx, tn)
         self.mgr.create(self.ctx, ap)
         self.mgr.create(self.ctx, epg)
-        cfg_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.CONFIG_TREE)
-        mon_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.MONITORED_TREE)
+        cfg_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.CONFIG_TREE)
+        mon_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.MONITORED_TREE)
         # Create my own tree representation
         my_cfg_tree = tree.StructuredHashTree()
         my_mon_tree = tree.StructuredHashTree()
@@ -305,10 +296,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         self.mgr.set_resource_sync_synced(self.ctx, ap)
         self.mgr.set_resource_sync_synced(self.ctx, epg)
         self.db_l.tt_maker.update(my_mon_tree, [ap, epg])
-        cfg_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.CONFIG_TREE)
-        mon_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.MONITORED_TREE)
+        cfg_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.CONFIG_TREE)
+        mon_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.MONITORED_TREE)
         self.assertEqual(my_mon_tree, mon_tree)
         self.assertEqual(my_cfg_tree, cfg_tree)
 
@@ -319,10 +308,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         self.db_l.tt_maker.update(my_mon_tree, [tn, epg])
         self.db_l.tt_maker.update(my_cfg_tree, [ap])
         # Refresh trees
-        cfg_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.CONFIG_TREE)
-        mon_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.MONITORED_TREE)
+        cfg_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.CONFIG_TREE)
+        mon_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.MONITORED_TREE)
         self.assertEqual(my_mon_tree, mon_tree,
                          'differences: %s' % my_mon_tree.diff(mon_tree))
         self.assertEqual(my_cfg_tree, cfg_tree)
@@ -332,10 +319,8 @@ class TestHashTreeDbListener(base.TestAimDBBase):
         self.db_l.tt_maker.update(my_mon_tree, [tn])
         self.db_l.tt_maker.update(my_cfg_tree, [epg])
         # Refresh trees
-        cfg_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.CONFIG_TREE)
-        mon_tree = self.tt_mgr.get(self.ctx, tn_rn,
-                                   tree=tree_manager.MONITORED_TREE)
+        cfg_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.CONFIG_TREE)
+        mon_tree = self.tt_mgr.get(tn_rn, tree=tree_manager.MONITORED_TREE)
         self.assertEqual(my_mon_tree, mon_tree)
         self.assertEqual(my_cfg_tree, cfg_tree)
 
@@ -350,8 +335,7 @@ class TestHashTreeDbListener(base.TestAimDBBase):
                'tenant_name': 'common', 'monitored': False, 'bi_filters': [],
                'in_filters': ['pr_1', 'reverse-pr_1', 'pr_2', 'reverse-pr_2']})
         subj = self.mgr.create(self.ctx, subj)
-        cfg_tree = self.tt_mgr.get(self.ctx, 'tn-common',
-                                   tree=tree_manager.CONFIG_TREE)
+        cfg_tree = self.tt_mgr.get('tn-common', tree=tree_manager.CONFIG_TREE)
         # verify pr_1 and its reverse are in the tree
         pr_1 = cfg_tree.find(
             ("fvTenant|common", "vzBrCP|c-name", "vzSubj|s-name",
@@ -364,8 +348,7 @@ class TestHashTreeDbListener(base.TestAimDBBase):
 
         self.mgr.update(self.ctx, subj, out_filters=['pr_2', 'reverse-pr_2'],
                         in_filters=['pr_2', 'reverse-pr_2'])
-        cfg_tree = self.tt_mgr.get(self.ctx, 'tn-common',
-                                   tree=tree_manager.CONFIG_TREE)
+        cfg_tree = self.tt_mgr.get('tn-common', tree=tree_manager.CONFIG_TREE)
         pr_1 = cfg_tree.find(
             ("fvTenant|common", "vzBrCP|c-name", "vzSubj|s-name",
              "vzOutTerm|outtmnl", "vzRsFiltAtt|pr_1"))
@@ -374,14 +357,6 @@ class TestHashTreeDbListener(base.TestAimDBBase):
              "vzOutTerm|outtmnl", "vzRsFiltAtt|reverse-pr_1"))
         self.assertIsNone(pr_1)
         self.assertIsNone(rev_pr_1)
-
-    def test_delete_all_trees(self):
-        self.mgr.create(self.ctx, aim_res.Tenant(name='common'))
-        self.mgr.create(self.ctx, aim_res.Tenant(name='tn1'))
-        self.mgr.create(self.ctx, aim_res.Tenant(name='tn2'))
-        self.assertTrue(len(self.tt_mgr.find(self.ctx)) > 0)
-        self.tt_mgr.delete_all(self.ctx)
-        self.assertEqual(0, len(self.tt_mgr.find(self.ctx)))
 
     def test_leaked_status(self):
         # Create parentless status object
@@ -410,7 +385,8 @@ class TestHashTreeDbListenerNoMockStore(base.TestAimDBBase):
         self.db_l = ht_db_l.HashTreeDbListener(aim_manager.AimManager())
 
     def test_duplicate_sg_rule_action_logs(self):
-        with mock.patch.object(self.db_l.tt_builder, 'build') as tt_build:
+        with mock.patch.object(self.db_l.tt_builder, 'build',
+                               return_value=({}, {}, {})) as tt_build:
             rule = self._get_example_aim_security_group_rule(
                 security_group_name='sg1', ip_protocol=1,
                 from_port='80', to_port='443',

--- a/aim/tests/unit/tools/cli/test_manager.py
+++ b/aim/tests/unit/tools/cli/test_manager.py
@@ -406,7 +406,7 @@ class TestManager(base.TestShell):
                         side_effect=get_mgr):
             with mock.patch('click.echo') as ce:
                 self.run_command('infra tag-list -t openstack_aid')
-        ce.called_once_with('uni/tn-tn1/tag-openstack_aid')
+        ce.assert_called_once_with('uni/tn-tn1/tag-openstack_aid')
 
     def test_tag_delete_command(self):
         apic_manager_object = mock.Mock()
@@ -420,7 +420,7 @@ class TestManager(base.TestShell):
                         side_effect=get_mgr):
             with mock.patch('click.echo') as ce:
                 self.run_command('infra tag-delete --dn uni/tn-tn1')
-        ce.called_once_with("uni/tn-tn1 object isn't a tag -- ignoring")
+        ce.assert_called_once_with("uni/tn-tn1 object isn't a tag -- ignoring")
         apic_manager_object.apic.transaction.assert_not_called()
 
         # Now actually delete a tag
@@ -429,7 +429,7 @@ class TestManager(base.TestShell):
             with mock.patch('click.echo') as ce:
                 self.run_command(
                     'infra tag-delete --dn uni/tn-tn1/tag-openstack_aid')
-        ce.called_once_with("uni/tn-tn1/tag-openstack_aid deleted")
+        ce.assert_called_once_with("uni/tn-tn1/tag-openstack_aid deleted")
         apic_manager_object.apic.DELETE.assert_called_with(
             '/mo/uni/tn-tn1/tag-openstack_aid.json')
 

--- a/aim/tools/cli/commands/infra.py
+++ b/aim/tools/cli/commands/infra.py
@@ -39,8 +39,10 @@ def get_apic_manager():
     manager = aim_manager.AimManager()
     db = infra_model.HostLinkManager(aim_ctx, manager)
     apic_system_id = config.CONF.apic_system_id
+    apic_system_id_length = config.CONF.apic_system_id_length
     return apic_manager.APICManager(db, logging, network_config, apic_config,
-                                    None, None, apic_system_id)
+                                    None, None, apic_system_id,
+                                    apic_system_id_length)
 
 
 @aimcli.aim.group(name='infra')

--- a/aim/tools/cli/commands/infra.py
+++ b/aim/tools/cli/commands/infra.py
@@ -40,9 +40,9 @@ def get_apic_manager():
     db = infra_model.HostLinkManager(aim_ctx, manager)
     apic_system_id = config.CONF.apic_system_id
     apic_system_id_length = config.CONF.apic_system_id_length
-    return apic_manager.APICManager(db, logging, network_config, apic_config,
-                                    None, None, apic_system_id,
-                                    apic_system_id_length)
+    return apic_manager.APICManager(
+        db, logging, network_config, apic_config, None, None,
+        apic_system_id, apic_system_id_length=apic_system_id_length)
 
 
 @aimcli.aim.group(name='infra')

--- a/aim/tools/cli/groups/aimcli.py
+++ b/aim/tools/cli/groups/aimcli.py
@@ -26,6 +26,8 @@ DEFAULT_FORMAT = 'tables'
 global_opts = [
     config.cfg.StrOpt('apic_system_id',
                       help="Prefix for APIC domain/names/profiles created"),
+    config.cfg.IntOpt('apic_system_id_length', default=16,
+                      help=("Maximum lengh for APIC system ID.")),
 ]
 config.CONF.register_opts(global_opts)
 curr_format = DEFAULT_FORMAT


### PR DESCRIPTION
This removes persisting the hashtrees in CONFIG trees. The hashtrees are stored in memory now. This will help reduce the DB size and the related issues because of size that was being caused. 