### PR TITLE
Remove python2 support for debian

### DIFF
--- a/debian/build-deb.sh
+++ b/debian/build-deb.sh
@@ -11,40 +11,6 @@ if [ ! -f debian/changelog.in ]; then
    exit 1
 fi
 
-# Build python2 package
-BUILD_DIR=${BUILD_DIR:-`pwd`/debbuild}
-mkdir -p $BUILD_DIR
-rm -rf $BUILD_DIR/*
-NAME=`python setup.py --name`
-VERSION_PY=`python setup.py --version`
-VERSION=`echo $VERSION_PY | sed -nre 's,([^\.]+.[^\.]+.[^\.]+)((\.)(0[^\.]+))?((\.)(dev.*))?,\1 \4 \7,p' | sed -re 's/ *$//g' | sed -re 's/ +/~/g'`
-REVISION=${REVISION:-1}
-python setup.py sdist --dist-dir $BUILD_DIR
-SOURCE_FILE=${NAME}-${VERSION_PY}.tar.gz
-tar -C $BUILD_DIR -xf $BUILD_DIR/$SOURCE_FILE
-SOURCE_DIR=$BUILD_DIR/${NAME}-${VERSION_PY}
-cp -H -r debian $SOURCE_DIR/
-sed -e "s/@VERSION@/$VERSION/" -e "s/@REVISION@/$REVISION/" ${SOURCE_DIR}/debian/changelog.in > ${SOURCE_DIR}/debian/changelog
-
-mv $BUILD_DIR/$SOURCE_FILE $BUILD_DIR/${NAME}_${VERSION}.orig.tar.gz
-pushd ${SOURCE_DIR}
-debuild -d -us -uc
-popd
-
-# Save the python2 package
-cp debbuild/*.deb .
-rm -rf debbuild
-
-# Prepare build scripts for python3
-cp debian/control .
-cp debian/rules .
-sed -i "s/python/python3/g" debian/control
-sed -i "s/Package: aci-integration-module/Package: python3-aci-integration-module/g" debian/control
-sed -i "s/Python2.7/Python3/g" debian/control
-sed -i "s/2.7/3.3/g" debian/control
-sed -i "s/acitoolkit/python3-acitoolkit/g" debian/control
-sed -i "s/python2/python3/g" debian/rules
-
 # Build the python3 package
 BUILD_DIR=${BUILD_DIR:-`pwd`/debbuild}
 mkdir -p $BUILD_DIR
@@ -64,8 +30,3 @@ mv $BUILD_DIR/$SOURCE_FILE $BUILD_DIR/${NAME}_${VERSION}.orig.tar.gz
 pushd ${SOURCE_DIR}
 debuild -d -us -uc
 popd
-
-# restore the original files and debian packages
-mv control debian/control
-mv rules debian/rules
-mv *.deb debbuild/

--- a/debian/control
+++ b/debian/control
@@ -1,17 +1,17 @@
 Source: aci-integration-module
-Section: python
+Section: python3
 Priority: optional
 Maintainer: Cisco Systems, Inc. <aci-integration-module@noironetworks.com>
-Build-Depends: debhelper (>= 9), dh-systemd, python-setuptools (>= 3.3), python-all (>= 2.7)
+Build-Depends: debhelper (>= 9), dh-systemd, python3-setuptools (>= 3.3), python3-all (>= 3.3)
 Standards-Version: 3.9.5
 Homepage: http://github.com/noironetworks/aci-integration-module/
 Vcs-Git: git://github.com/noironetworks/aci-integration-module.git
 Vcs-Browser: http://github.com/noironetworks/aci-integration-module
 
-Package: aci-integration-module
+Package: python3-aci-integration-module
 Architecture: all
-Depends: python-click-cli (>=3.3) | python-click (>=6.2), python-oslo.config (>=1.4),
-         ${misc:Depends}, alembic, acitoolkit, python-apicapi, python-click, python-jsonschema,
-         python-pbr, python-tabulate, python-semantic-version
-Description: Python2.7 library for programming ACI
+Depends: python3-click-cli (>=3.3) | python3-click (>=6.2), python3-oslo.config (>=1.4),
+         ${misc:Depends}, alembic, python3-acitoolkit, python3-apicapi, python3-click, python3-jsonschema,
+         python3-pbr, python3-tabulate, python3-semantic-version, ${python3:Depends}
+Description: Python3 library for programming ACI
  Library for programming ACI 

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
 %:
-	dh $@ --with systemd --with python2 --buildsystem=pybuild
+	dh $@ --with systemd --with python3 --buildsystem=pybuild
 
 override_dh_auto_clean:
 	dh_clean


### PR DESCRIPTION
Python2 is EOL, so remove support for it in debian builds.