### PR TITLE
Fix stale tenant cleanup

### DIFF
--- a/aim/tests/unit/agent/test_agent.py
+++ b/aim/tests/unit/agent/test_agent.py
@@ -461,6 +461,13 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # Now tenant will be deleted (still served)
         agent._reconciliation_cycle()
         self.assertIsNone(agent.current_universe.state[tn1.rn].root)
+        # It takes 3 iterations in each multiverse before tenant
+        # deletion is allowed. It has to clear all multiverses before
+        # the tenant is finally removed.
+        for loop_num, _ in enumerate(tree_manager.SUPPORTED_TREES):
+            agent._reconciliation_cycle()
+            agent._reconciliation_cycle()
+            agent._reconciliation_cycle()
         tree1 = agent.tree_manager.find(self.ctx, root_rn=[tn1.rn])
         self.assertEqual(0, len(tree1))
 
@@ -632,6 +639,13 @@ class TestAgent(base.TestAimDBBase, test_aci_tenant.TestAciClientMixin):
         # Agent will delete remaining objects
         agent._reconciliation_cycle()
         self.assertTrue(tn1.rn in desired_monitor.serving_tenants)
+        # It takes 3 iterations in each multiverse before tenant
+        # deletion is allowed. It has to clear all multiverses before
+        # the tenant is finally removed.
+        for loop_num, _ in enumerate(tree_manager.SUPPORTED_TREES):
+            agent._reconciliation_cycle()
+            agent._reconciliation_cycle()
+            agent._reconciliation_cycle()
         # Now deletion happens
         agent._reconciliation_cycle()
         self.assertTrue(tn1.rn not in desired_monitor.serving_tenants)


### PR DESCRIPTION
Commit 4fb4cabf8a7e0cbb9546b892d4a3867a19fa0d04 was created to avoid cases where stale tenant state is left in APIC, due to hash trees being deleted before the reconcile could create the delete requests to APIC. The fix failed to cover the case where tenants are created and then deleted before a reconcile happens, and would fail to delete the hash trees and root, causing AIM to consider the stale trees during the reconciliation cycle. This patch uses an approach to wait 3 cycles per universe (config, operational, and monitored) before allowing tenant deletion to happen for that universe.  Note that all 3 universes must allow the tenant state to be deleted, making for up to 9 reconciliation cycles before a tenant is finally removed.