### PR TITLE
Fix python3 build

### DIFF
--- a/rpm/aci-integration-module.spec.in
+++ b/rpm/aci-integration-module.spec.in
@@ -5,7 +5,7 @@
 %define aim_http aim-http-server.service
 %global srcname aci-integration-module
 
-Name:           %{srcname}
+Name:           python3-%{srcname}
 Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
 Summary:	Python library for programming ACI


### PR DESCRIPTION
Packages for python3 should be prefaced with "python3-".