### PR TITLE
Fix isAlive

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -401,7 +401,7 @@ class ApicClientsContext(object):
 
             while flag['monitor_runs']:
                 for thd, name in threads:
-                    if thd and not thd.isAlive():
+                    if thd and not thd.is_alive():
                         if name_to_retry[name] and name_to_retry[
                                 name].get() >= max_retries:
                             utils.perform_harakiri(

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -359,14 +359,14 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
         self.universe.ac_context.monitor_max_backoff = 0
         self.universe.ac_context.monitor_sleep_time = 0
         t = mock.Mock()
-        t.isAlive = mock.Mock(return_value=False)
+        t.is_alive = mock.Mock(return_value=False)
         self.universe.ac_context.subs_thread = t
         with mock.patch.object(utils, 'perform_harakiri') as harakiri:
             self.universe.ac_context._thread_monitor({'monitor_runs': 4})
-            self.assertEqual(4, t.isAlive.call_count)
+            self.assertEqual(4, t.is_alive.call_count)
             harakiri.assert_called_once_with(mock.ANY, mock.ANY)
             harakiri.reset_mock()
-            t.isAlive = mock.Mock(return_value=True)
+            t.is_alive = mock.Mock(return_value=True)
             self.universe.ac_context._thread_monitor({'monitor_runs': 4})
             self.assertEqual(0, harakiri.call_count)
 


### PR DESCRIPTION
For python3.9, the threading.Thread isAlive method was replaced with the is_alive method.

(cherry picked from commit 41669f05eb0d809f2538a8916e77361563e58a0b)