### PR TITLE
Fix for AIM config not converging for hostProtRemoteIP 0.0.0.0/32 [CSCwp32570]

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -824,6 +824,14 @@ def hostprot_remoteIp_converter(object_dict, otype, helper,
             res_dict[attr] = id[index]
         if object_dict.get(aci_attr):
             res_dict[aim_attr] = [object_dict[aci_attr]]
+        ip_addr = object_dict.get(aci_attr)
+        if ip_addr:
+            # Normalize the IP address
+            # this is necessary for composing Security Group Rules usecase.
+            # Since APIC strips /32 from customer config.
+            normalized_ip = ('0.0.0.0/32' if ip_addr == '0.0.0.0'
+                             else ip_addr)
+            res_dict[aim_attr] = [normalized_ip]
         result.append(default_to_resource(res_dict, helper, to_aim=True))
     else:
         aci_type = helper['resource']


### PR DESCRIPTION
In Openstack a security group rule is configured with Remote IP 0.0.0.0/32, which has an intent to disable all communication towards port that it's assigned to. AIM component of ACI Neutron plugin takes this security group rule and pushes it to APIC as hostprotRemoteIp Policy.
When the policy is programmed in APIC, it's automatically converted to 0.0.0.0 remote IP (the mast /32 is deleted).

At this point AIM would never converge for the corresponding project, since it sees that different remote IP is programmed in APIC (0.0.0.0 vs 0.0.0.0/32) and it tried to correct it by deleting 0.0.0.0 and configuring again 0.0.0.0/32 at the same run.
