### PR TITLE
osp18 agent id name changes

### DIFF
--- a/aim/agent/aid/service.py
+++ b/aim/agent/aid/service.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
 import signal
 import sys
 import time
@@ -94,7 +95,13 @@ class AID(object):
         # AIM's
         self.manager = aim_manager.AimManager()
         self.tree_manager = tree_manager.HashTreeManager()
-        self.agent_id = 'aid-%s' % self.host
+        pod_ordinal = os.environ.get('POD_ORDINAL')
+        if pod_ordinal:
+            self.agent_id = "aid-%s-%s" % (conf.aim.aim_agentid_base,
+                                           pod_ordinal)
+        else:
+            # TripleO deployment
+            self.agent_id = 'aid-%s' % self.host
         self.agent = resource.Agent(id=self.agent_id, agent_type=AGENT_TYPE,
                                     host=self.host, binary_file=AGENT_BINARY,
                                     description=AGENT_DESCRIPTION,

--- a/aim/config.py
+++ b/aim/config.py
@@ -89,6 +89,8 @@ agent_opts = [
     cfg.StrOpt('aim_service_identifier', default=socket.gethostname(),
                help="(Restart Required) Identifier for this specific AID "
                     "service, defaults to the hostname."),
+    cfg.StrOpt('aim_agentid_base', default=socket.gethostname(),
+               help="Base identifier for agent ID in k8s StatefulSets."),
     cfg.StrOpt('aim_store', default='sql', choices=['k8s', 'sql'],
                help="Backend store of this AIM installation. It can be either "
                     "SQL via sqlalchemy or k8s via the Kubernetes API server."


### PR DESCRIPTION
In OSP18, since pods names are ephemeral, we want to modify the naming of AID agents, so that the naming doesnt change if redeployed. This would make sure theres no thrashing of tenants assignments.