### PR TITLE
Fix ESP and APIC errors

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -571,6 +571,12 @@ class AciUniverse(base.HashTreeStoredUniverse):
                 self.get_state_by_type(base.MONITOR_UNIVERSE),
                 self.get_state_by_type(base.OPER_UNIVERSE)]
 
+    def _consume_push_failures(self):
+        failed = False
+        for manager in list(self.serving_tenants.values()):
+            failed = manager.consume_push_failures() or failed
+        return failed
+
     @property
     def name(self):
         return "ACI_Config_Universe"
@@ -640,6 +646,12 @@ class AciUniverse(base.HashTreeStoredUniverse):
             # failure in serve method. Restart the process
             utils.perform_harakiri(LOG,
                                    "Error in serve. Reset the tenants")
+
+    def reconcile(self, context, other_universe, delete_candidates):
+        had_push_failures = self._consume_push_failures()
+        diff = super(AciUniverse, self).reconcile(
+            context, other_universe, delete_candidates)
+        return self._consume_push_failures() or had_push_failures or diff
 
     def tenant_creation_failed(self, aim_object, reason='unknown',
                                error=errors.UNKNOWN):

--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -84,6 +84,17 @@ ip_protocol = mapped_attribute(t.ip_protocol)
 ethertype = mapped_attribute(t.ethertype)
 
 
+def hostprot_rule_protocol(object_dict, attribute, to_aim=True):
+    curr = default_attribute_converter(object_dict, attribute, to_aim=to_aim)
+    if to_aim:
+        if str(curr) == t.ip_protocol.get('50'):
+            return '50'
+        return str(curr)
+    if str(curr) == '50':
+        return '50'
+    return t.ip_protocol.get(str(curr), str(curr))
+
+
 def port_with_ssh(object_dict, attribute, to_aim=True):
     # ACI releases prior to 5.x  wouldn't aaccept 'ssh' as a valid
     # fromPort or toPort value. In order to support both 5.x and prior
@@ -1236,7 +1247,7 @@ resource_map = {
          'skip': ['remote_ips', 'remote_group_id', 'tDn'],
          'exceptions': {
              'protocol': {'other': 'ip_protocol',
-                          'converter': ip_protocol},
+                          'converter': hostprot_rule_protocol},
              'fromPort': {'other': 'from_port',
                           'converter': port_with_ssh},
              'toPort': {'other': 'to_port',
@@ -1252,7 +1263,7 @@ resource_map = {
          'skip': ['remote_ips'],
          'exceptions': {
              'protocol': {'other': 'ip_protocol',
-                          'converter': ip_protocol},
+                          'converter': hostprot_rule_protocol},
              'fromPort': {'other': 'from_port',
                           'converter': port_with_ssh},
              'toPort': {'other': 'to_port',

--- a/aim/agent/aid/universes/aci/tenant.py
+++ b/aim/agent/aid/universes/aci/tenant.py
@@ -368,6 +368,15 @@ class AciTenantManager(utils.AIMThread):
     def _reset_object_backlog(self):
         self.object_backlog = Queue.Queue()
 
+    def note_push_failure(self, aim_object, method, error):
+        self.failure_log[(method, repr(aim_object))] = {
+            'method': method, 'object': repr(aim_object), 'error': str(error)}
+
+    def consume_push_failures(self):
+        had_failures = bool(self.failure_log)
+        self.failure_log = {}
+        return had_failures
+
     def kill(self, *args, **kwargs):
         try:
             self._unsubscribe_tenant(kill=True)
@@ -661,6 +670,7 @@ class AciTenantManager(utils.AIMThread):
                             LOG.error("An error has occurred during %s for "
                                       "object %s: %s" % (method, aim_object,
                                                          str(e)))
+                            self.note_push_failure(aim_object, method, e)
                             if method == base_universe.CREATE:
                                 err_type = (
                                     self.error_handler.analyze_exception(e))

--- a/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_tenant.py
@@ -694,6 +694,18 @@ class TestAciTenant(base.TestAimDBBase, TestAciClientMixin):
         self.manager.push_aim_resources({'delete': [bda1, bda2]})
         self.manager._push_aim_resources()
 
+        self.manager.creation_failed = mock.Mock()
+        self.manager.ac_context.aci_session.post_body_dict = mock.Mock(
+            side_effect=apic_client.cexc.ApicResponseNotOk(
+                request='my_request', status=400,
+                reason='bad request', err_text='bad request text',
+                err_code=120))
+        self.manager.push_aim_resources({'create': [bd1]})
+        self.manager._push_aim_resources()
+        self.assertTrue(self.manager.consume_push_failures())
+        self.assertFalse(self.manager.consume_push_failures())
+        self.assertEqual(1, self.manager.creation_failed.call_count)
+
     def test_fill_events_noop(self):
         # On unchanged data, fill events is a noop
         events = self._init_event()

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -131,6 +131,17 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
             self.assertTrue(isinstance(self.universe.state[tenant],
                                        structured_tree.StructuredHashTree))
 
+    def test_reconcile_reports_push_failures(self):
+        tenant = mock.Mock()
+        tenant.consume_push_failures = mock.Mock(side_effect=[True, False])
+        self.universe.serving_tenants['tn-fail'] = tenant
+        other = mock.Mock()
+        with mock.patch.object(
+                aci_universe.base.HashTreeStoredUniverse, 'reconcile',
+                return_value=False):
+            self.assertTrue(
+                self.universe.reconcile(self.ctx, other, set()))
+
     def test_serve_exception(self):
         tenant_list = ['tn-%s' % x for x in range(10)]
         self.universe.serve(self.ctx, tenant_list)

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1331,7 +1331,7 @@ class TestAciToAimConverterSecurityGroupRule(TestAciToAimConverterBase,
     reverse_map_output = [
         {'exceptions': {
             'ip_protocol': {'other': 'protocol',
-                            'converter': converter.ip_protocol},
+                            'converter': converter.hostprot_rule_protocol},
             'from_port': {'other': 'fromPort',
                           'converter': converter.port_with_ssh},
             'to_port': {'other': 'toPort',
@@ -2432,7 +2432,7 @@ class TestAciToAimConverterSystemSecurityGroupRule(TestAciToAimConverterBase,
     reverse_map_output = [
         {'exceptions': {
             'ip_protocol': {'other': 'protocol',
-                            'converter': converter.ip_protocol},
+                            'converter': converter.hostprot_rule_protocol},
             'from_port': {'other': 'fromPort',
                           'converter': converter.port_with_ssh},
             'to_port': {'other': 'toPort',
@@ -3540,7 +3540,12 @@ class TestAimToAciConverterSecurityGroupRule(TestAimToAciConverterBase,
                         from_port='80', to_port='443',
                         direction='egress', ethertype='2',
                         conn_track='normal', icmp_type='unspecified',
-                        icmp_code='unspecified', tDn='uni/test')]
+                        icmp_code='unspecified', tDn='uni/test'),
+                    base.TestAimDBBase._get_example_aim_security_group_rule(
+                        security_group_name='sg5', ip_protocol=50,
+                        remote_ips=['0.0.0.0/0'],
+                        direction='egress', ethertype='1',
+                        conn_track='normal')]
 
     sample_output = [
         [_aci_obj('hostprotRule',
@@ -3582,7 +3587,17 @@ class TestAimToAciConverterSecurityGroupRule(TestAimToAciConverterBase,
          _aci_obj('hostprotRsRemoteIpContainer',
                   dn='uni/tn-t1/pol-sg4/subj-sgs1/rule-rule1/'
                   'rsremoteIpContainer-[uni/test]',
-                  tDn='uni/test')]]
+                  tDn='uni/test')],
+        [_aci_obj('hostprotRule',
+                  dn='uni/tn-t1/pol-sg5/subj-sgs1/rule-rule1',
+                  protocol='50', direction='egress',
+                  fromPort='unspecified', toPort='unspecified',
+                  ethertype='ipv4', nameAlias='', connTrack='normal',
+                  icmpCode='unspecified', icmpType='unspecified'),
+         _aci_obj(
+             'hostprotRemoteIp',
+             dn='uni/tn-t1/pol-sg5/subj-sgs1/rule-rule1/ip-[0.0.0.0/0]',
+             addr='0.0.0.0/0')]]
 
 
 def get_example_aim_sg_remoteip_container(**kwargs):
@@ -5047,7 +5062,11 @@ class TestAimToAciConverterSystemSecurityGroupRule(TestAimToAciConverterBase,
             from_port='80', to_port='443',
             direction='egress', ethertype='2',
             conn_track='normal', icmp_type='unspecified',
-            icmp_code='unspecified')]
+            icmp_code='unspecified'),
+        base.TestAimDBBase._get_example_aim_system_security_group_rule(
+            security_group_subject_name='sgs5', ip_protocol=50,
+            remote_ips=['0.0.0.0/0'], direction='egress',
+            ethertype='1', conn_track='normal')]
 
     sample_output = [
         [_aci_obj('hostprotRule',
@@ -5087,7 +5106,19 @@ class TestAimToAciConverterSystemSecurityGroupRule(TestAimToAciConverterBase,
                   protocol='tcp', direction='egress',
                   fromPort='http', toPort='https',
                   ethertype='ipv6', nameAlias='', connTrack='normal',
-                  icmpCode='unspecified', icmpType='unspecified')]]
+                  icmpCode='unspecified', icmpType='unspecified')],
+        [_aci_obj('hostprotRule',
+                  dn='uni/tn-common/pol-openstack_aid_SystemSecurityGroup/'
+                     'subj-sgs5/rule-rule1',
+                  protocol='50', direction='egress',
+                  fromPort='unspecified', toPort='unspecified',
+                  ethertype='ipv4', nameAlias='', connTrack='normal',
+                  icmpCode='unspecified', icmpType='unspecified'),
+         _aci_obj(
+             'hostprotRemoteIp',
+             dn='uni/tn-common/pol-openstack_aid_SystemSecurityGroup/'
+                'subj-sgs5/rule-rule1/ip-[0.0.0.0/0]',
+             addr='0.0.0.0/0')]]
 
 
 class TestAciToAimConverterQosReq(TestAciToAimConverterBase,


### PR DESCRIPTION
This patch addresses two issues:
* When protocol 50 is configured ("esp"),n a security group rule, AIM sends it with the string "esp" instead of the protocol number "50", which is rejected by APIC
* The above error is missed, and AIM thinks that the security group rule is present in APIC, which it is not.