### PR TITLE
Fix stale tenant state

### DIFF
--- a/aim/agent/aid/universes/aci/aci_universe.py
+++ b/aim/agent/aid/universes/aci/aci_universe.py
@@ -586,7 +586,6 @@ class AciUniverse(base.HashTreeStoredUniverse):
         if self.ac_context.is_session_reconnected is True:
             self.reset(context, serving_tenants)
             self.ac_context.is_session_reconnected = False
-            return
         try:
             serving_tenant_copy = serving_tenants
             serving_tenants = {}
@@ -663,11 +662,13 @@ class AciUniverse(base.HashTreeStoredUniverse):
         # Reset can only be called during reconciliation. serving_tenants
         # can't be modified meanwhile
         global serving_tenants
-        LOG.warning('Reset called for roots %s' % tenants)
-        for root in tenants:
-            if root in serving_tenants:
+        roots = list(tenants)
+        LOG.warning('Reset called for roots %s' % roots)
+        for root in roots:
+            tenant_mgr = serving_tenants.pop(root, None)
+            if tenant_mgr:
                 try:
-                    serving_tenants[root].kill()
+                    tenant_mgr.kill()
                 except Exception:
                     LOG.error(traceback.format_exc())
                     LOG.error('Failed to reset tenant %s' % root)

--- a/aim/tests/unit/agent/aid_universes/test_aci_universe.py
+++ b/aim/tests/unit/agent/aid_universes/test_aci_universe.py
@@ -105,6 +105,37 @@ class TestAciUniverseMixin(test_aci_tenant.TestAciClientMixin):
                 # This was replaced fresh
                 self.assertIsNot(v, self.universe.serving_tenants[k])
 
+    def test_serve_session_reconnect_replaces_serving_tenants(self):
+        tenant_list = ['tn-%s' % x for x in range(2)]
+        self.universe.serve(self.ctx, tenant_list)
+        serving_tenants_copy = dict(self.universe.serving_tenants)
+        for tenant_mgr in serving_tenants_copy.values():
+            tenant_mgr.kill = mock.Mock()
+            tenant_mgr.is_dead = mock.Mock(return_value=False)
+
+        self.universe.ac_context.is_session_reconnected = True
+        self.universe.serve(self.ctx, tenant_list)
+
+        self.assertFalse(self.universe.ac_context.is_session_reconnected)
+        self.assertEqual(set(tenant_list),
+                         set(self.universe.serving_tenants.keys()))
+        for root, tenant_mgr in serving_tenants_copy.items():
+            tenant_mgr.kill.assert_called_once_with()
+            self.assertIsNot(tenant_mgr, self.universe.serving_tenants[root])
+
+    def test_reset_discards_serving_tenant_even_if_kill_does_not_exit(self):
+        tenant_list = ['tn-%s' % x for x in range(2)]
+        self.universe.serve(self.ctx, tenant_list)
+        stale_mgr = self.universe.serving_tenants['tn-0']
+        stale_mgr.kill = mock.Mock()
+        stale_mgr.is_dead = mock.Mock(return_value=False)
+
+        self.universe.reset(self.ctx, ['tn-0'])
+
+        stale_mgr.kill.assert_called_once_with()
+        self.assertNotIn('tn-0', self.universe.serving_tenants)
+        self.assertIn('tn-1', self.universe.serving_tenants)
+
     def test_observe(self):
         tenant_list = ['tn-%s' % x for x in range(10)]
         self.universe.serve(self.ctx, tenant_list)


### PR DESCRIPTION
If the ACI Universe's reset method is called, all of the tenants have their kill method called, which is meant to shut down the thread. If the thread never exits, then the tenants state can never advance. This patch ensures that a new ACITenantManager object (and its corresponding thread) get created when the reset method is called, preventing this from happening.