### PR TITLE
Fix ESP error

### DIFF
--- a/aim/agent/aid/universes/aci/converter.py
+++ b/aim/agent/aid/universes/aci/converter.py
@@ -84,6 +84,17 @@ ip_protocol = mapped_attribute(t.ip_protocol)
 ethertype = mapped_attribute(t.ethertype)
 
 
+def hostprot_rule_protocol(object_dict, attribute, to_aim=True):
+    curr = default_attribute_converter(object_dict, attribute, to_aim=to_aim)
+    if to_aim:
+        if str(curr) == t.ip_protocol.get('50'):
+            return '50'
+        return str(curr)
+    if str(curr) == '50':
+        return '50'
+    return t.ip_protocol.get(str(curr), str(curr))
+
+
 def port_with_ssh(object_dict, attribute, to_aim=True):
     # ACI releases prior to 5.x  wouldn't aaccept 'ssh' as a valid
     # fromPort or toPort value. In order to support both 5.x and prior
@@ -1236,7 +1247,7 @@ resource_map = {
          'skip': ['remote_ips', 'remote_group_id', 'tDn'],
          'exceptions': {
              'protocol': {'other': 'ip_protocol',
-                          'converter': ip_protocol},
+                          'converter': hostprot_rule_protocol},
              'fromPort': {'other': 'from_port',
                           'converter': port_with_ssh},
              'toPort': {'other': 'to_port',
@@ -1252,7 +1263,7 @@ resource_map = {
          'skip': ['remote_ips'],
          'exceptions': {
              'protocol': {'other': 'ip_protocol',
-                          'converter': ip_protocol},
+                          'converter': hostprot_rule_protocol},
              'fromPort': {'other': 'from_port',
                           'converter': port_with_ssh},
              'toPort': {'other': 'to_port',

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -1331,7 +1331,7 @@ class TestAciToAimConverterSecurityGroupRule(TestAciToAimConverterBase,
     reverse_map_output = [
         {'exceptions': {
             'ip_protocol': {'other': 'protocol',
-                            'converter': converter.ip_protocol},
+                            'converter': converter.hostprot_rule_protocol},
             'from_port': {'other': 'fromPort',
                           'converter': converter.port_with_ssh},
             'to_port': {'other': 'toPort',
@@ -2432,7 +2432,7 @@ class TestAciToAimConverterSystemSecurityGroupRule(TestAciToAimConverterBase,
     reverse_map_output = [
         {'exceptions': {
             'ip_protocol': {'other': 'protocol',
-                            'converter': converter.ip_protocol},
+                            'converter': converter.hostprot_rule_protocol},
             'from_port': {'other': 'fromPort',
                           'converter': converter.port_with_ssh},
             'to_port': {'other': 'toPort',
@@ -3540,7 +3540,12 @@ class TestAimToAciConverterSecurityGroupRule(TestAimToAciConverterBase,
                         from_port='80', to_port='443',
                         direction='egress', ethertype='2',
                         conn_track='normal', icmp_type='unspecified',
-                        icmp_code='unspecified', tDn='uni/test')]
+                        icmp_code='unspecified', tDn='uni/test'),
+                    base.TestAimDBBase._get_example_aim_security_group_rule(
+                        security_group_name='sg5', ip_protocol=50,
+                        remote_ips=['0.0.0.0/0'],
+                        direction='egress', ethertype='1',
+                        conn_track='normal')]
 
     sample_output = [
         [_aci_obj('hostprotRule',
@@ -3582,7 +3587,17 @@ class TestAimToAciConverterSecurityGroupRule(TestAimToAciConverterBase,
          _aci_obj('hostprotRsRemoteIpContainer',
                   dn='uni/tn-t1/pol-sg4/subj-sgs1/rule-rule1/'
                   'rsremoteIpContainer-[uni/test]',
-                  tDn='uni/test')]]
+                  tDn='uni/test')],
+        [_aci_obj('hostprotRule',
+                  dn='uni/tn-t1/pol-sg5/subj-sgs1/rule-rule1',
+                  protocol='50', direction='egress',
+                  fromPort='unspecified', toPort='unspecified',
+                  ethertype='ipv4', nameAlias='', connTrack='normal',
+                  icmpCode='unspecified', icmpType='unspecified'),
+         _aci_obj(
+             'hostprotRemoteIp',
+             dn='uni/tn-t1/pol-sg5/subj-sgs1/rule-rule1/ip-[0.0.0.0/0]',
+             addr='0.0.0.0/0')]]
 
 
 def get_example_aim_sg_remoteip_container(**kwargs):
@@ -5047,7 +5062,11 @@ class TestAimToAciConverterSystemSecurityGroupRule(TestAimToAciConverterBase,
             from_port='80', to_port='443',
             direction='egress', ethertype='2',
             conn_track='normal', icmp_type='unspecified',
-            icmp_code='unspecified')]
+            icmp_code='unspecified'),
+        base.TestAimDBBase._get_example_aim_system_security_group_rule(
+            security_group_subject_name='sgs5', ip_protocol=50,
+            remote_ips=['0.0.0.0/0'], direction='egress',
+            ethertype='1', conn_track='normal')]
 
     sample_output = [
         [_aci_obj('hostprotRule',
@@ -5087,7 +5106,19 @@ class TestAimToAciConverterSystemSecurityGroupRule(TestAimToAciConverterBase,
                   protocol='tcp', direction='egress',
                   fromPort='http', toPort='https',
                   ethertype='ipv6', nameAlias='', connTrack='normal',
-                  icmpCode='unspecified', icmpType='unspecified')]]
+                  icmpCode='unspecified', icmpType='unspecified')],
+        [_aci_obj('hostprotRule',
+                  dn='uni/tn-common/pol-openstack_aid_SystemSecurityGroup/'
+                     'subj-sgs5/rule-rule1',
+                  protocol='50', direction='egress',
+                  fromPort='unspecified', toPort='unspecified',
+                  ethertype='ipv4', nameAlias='', connTrack='normal',
+                  icmpCode='unspecified', icmpType='unspecified'),
+         _aci_obj(
+             'hostprotRemoteIp',
+             dn='uni/tn-common/pol-openstack_aid_SystemSecurityGroup/'
+                'subj-sgs5/rule-rule1/ip-[0.0.0.0/0]',
+             addr='0.0.0.0/0')]]
 
 
 class TestAciToAimConverterQosReq(TestAciToAimConverterBase,


### PR DESCRIPTION
When protocol 50 is configured ("esp"),n a security group rule, AIM sends it with the string "esp" instead of the protocol number "50", which is rejected by APIC. This fixes the convert to ensure that the protocol number is used.