### PR TITLE
Fix DB migration

### DIFF
--- a/aim/agent/aid/universes/base_universe.py
+++ b/aim/agent/aid/universes/base_universe.py
@@ -566,7 +566,7 @@ class HashTreeStoredUniverse(AimUniverse):
 
     def cleanup_state(self, context, key):
         if key in list(self._deleting_roots.keys()):
-            del(self._deleting_roots[key])
+            del self._deleting_roots[key]
 
     def creation_succeeded(self, aim_object):
         pass

--- a/aim/api/resource.py
+++ b/aim/api/resource.py
@@ -131,7 +131,7 @@ class ResourceBase(object):
 
         missing = object()
 
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
 
         for attr in self.user_attributes():

--- a/aim/db/migration/alembic_migrations/env.py
+++ b/aim/db/migration/alembic_migrations/env.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 
+import contextlib
 from logging.config import fileConfig
 
 from alembic import context
@@ -43,6 +44,15 @@ target_metadata = model_base.Base.metadata
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
+
+
+@contextlib.contextmanager
+def _connection_context(connection, close_connection):
+    if close_connection:
+        with connection:
+            yield connection
+    else:
+        yield connection
 
 
 def run_migrations_offline():
@@ -81,11 +91,12 @@ def run_migrations_online():
             prefix='sqlalchemy.',
             poolclass=pool.NullPool)
 
-    if isinstance(connectable, Connection):
+    close_connection = not isinstance(connectable, Connection)
+    if not close_connection:
         connection = connectable
     else:
         connection = connectable.connect()
-    with connection:
+    with _connection_context(connection, close_connection):
         context.configure(
             connection=connection,
             target_metadata=target_metadata,

--- a/aim/db/migration/alembic_migrations/versions/88a419c00e59_add_path_mode.py
+++ b/aim/db/migration/alembic_migrations/versions/88a419c00e59_add_path_mode.py
@@ -55,5 +55,6 @@ def upgrade():
         with session.begin():
             migration(session)
 
+
 def downgrade():
     pass

--- a/aim/db/migration/alembic_migrations/versions/a94984a4452b_security_groups_remoteipcont.py
+++ b/aim/db/migration/alembic_migrations/versions/a94984a4452b_security_groups_remoteipcont.py
@@ -79,9 +79,7 @@ def upgrade():
         sa.Column('name', sa.String(64), nullable=False, primary_key=True))
     stmt = sa.insert(aim_aci_supported_mos_table).values(name="remoteipcont",
                                                          supports=False)
-    dbsession = sa.orm.Session(bind=op.get_bind())
-    dbsession.execute(stmt)
-    dbsession.commit()
+    op.get_bind().execute(stmt)
 
 
 def downgrade():

--- a/aim/db/migration/alembic_migrations/versions/aceb1ac13668_vmm_policy.py
+++ b/aim/db/migration/alembic_migrations/versions/aceb1ac13668_vmm_policy.py
@@ -113,7 +113,7 @@ def upgrade():
         sa.Column('monitored', sa.Boolean, nullable=False, default=False),
         sa.PrimaryKeyConstraint('aim_id'))
 
-    def migraiton2(session):
+    def migration2(session):
         for obj in new_vmms + new_phys:
             mgr.create(ctx, obj)
 

--- a/aim/db/migration/alembic_migrations/versions/cf83ad8832f0_hashring_parameters_vnodes.py
+++ b/aim/db/migration/alembic_migrations/versions/cf83ad8832f0_hashring_parameters_vnodes.py
@@ -44,9 +44,7 @@ def upgrade():
     stmt = sa.insert(aim_consistent_hashring_params_table).values(
         name="vnodes",
         value=40)
-    dbsession = sa.orm.Session(bind=op.get_bind())
-    dbsession.execute(stmt)
-    dbsession.commit()
+    op.get_bind().execute(stmt)
 
 
 def downgrade():

--- a/aim/db/migration/alembic_migrations/versions/dd2f91cf1b1e_set_nat_bd_ip_learn.py
+++ b/aim/db/migration/alembic_migrations/versions/dd2f91cf1b1e_set_nat_bd_ip_learn.py
@@ -72,8 +72,6 @@ def get_bd_l3out_values(session):
     for row in session.query(bd_l3outs).all():
         bd_id, name = row
         values.append({'bd_aim_id': bd_id})
-    # this commit appears to be necessary to allow further operations
-    session.commit()
     return values
 
 

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -55,7 +55,7 @@ def etcdir(*p):
 
 def resource_equal(self, other):
 
-    if type(self) != type(other):
+    if type(self) is not type(other):
         return False
     for attr in self.identity_attributes:
         if getattr(self, attr) != getattr(other, attr):

--- a/aim/tests/unit/agent/aid_universes/test_converter.py
+++ b/aim/tests/unit/agent/aid_universes/test_converter.py
@@ -2846,7 +2846,7 @@ class TestAimToAciConverterEPGNoUseg(TestAimToAciConverterEPG):
             for tla in tll:
                 if 'fvRsDomAtt' in tla:
                     if 'classPref' in tla['fvRsDomAtt']['attributes']:
-                        del(tla['fvRsDomAtt']['attributes']['classPref'])
+                        del tla['fvRsDomAtt']['attributes']['classPref']
         aim_cfg.CONF.set_override('disable_micro_segmentation', True, 'aim')
 
 
@@ -3598,14 +3598,15 @@ class TestAimToAciConverterSecurityGroupRule(TestAimToAciConverterBase,
                   fromPort='rtsp', toPort='rtsp',
                   ethertype='ipv4', nameAlias='', connTrack='reflexive',
                   icmpCode='unspecified', icmpType='unspecified')],
-         _aci_obj(hostprotRule
+        [_aci_obj('hostprotRule',
+                  dn='uni/tn-t1/pol-sg6/subj-sgs1/rule-rule1',
                   protocol='50', direction='egress',
                   fromPort='unspecified', toPort='unspecified',
                   ethertype='ipv4', nameAlias='', connTrack='normal',
                   icmpCode='unspecified', icmpType='unspecified'),
          _aci_obj(
              'hostprotRemoteIp',
-             dn='uni/tn-t1/pol-sg5/subj-sgs1/rule-rule1/ip-[0.0.0.0/0]',
+             dn='uni/tn-t1/pol-sg6/subj-sgs1/rule-rule1/ip-[0.0.0.0/0]',
              addr='0.0.0.0/0')]]
 
 

--- a/aim/tests/unit/test_migration.py
+++ b/aim/tests/unit/test_migration.py
@@ -13,6 +13,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import contextlib
+import importlib
+import os
+import runpy
+
+import mock
+import sqlalchemy as sa
+
 from aim import aim_manager
 from aim.api import infra
 from aim.api import resource
@@ -26,6 +34,148 @@ from aim.db.migration.data_migration import fix_bd_garp
 from aim.db.migration.data_migration import host_domain_mapping_v2
 from aim.db.migration.data_migration import status_add_tenant
 from aim.tests import base
+from aim.tools.cli.commands import db_migration
+
+
+class TestAlembicTransactions(base.BaseTestCase):
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _transaction_context():
+        yield
+
+    def test_env_does_not_close_external_connection(self):
+        class FakeConfig(object):
+            config_file_name = base.etcdir('aim.conf.test')
+
+            def __init__(self, connection):
+                self.attributes = {'connection': connection}
+
+        class FakeContext(object):
+            def __init__(self, connection):
+                self.config = FakeConfig(connection)
+                self.configured_connection = None
+
+            def is_offline_mode(self):
+                return False
+
+            def configure(self, **kwargs):
+                self.configured_connection = kwargs['connection']
+
+            def begin_transaction(self):
+                return TestAlembicTransactions._transaction_context()
+
+            def run_migrations(self):
+                pass
+
+        engine = sa.create_engine('sqlite://')
+        connection = engine.connect()
+        transaction = connection.begin()
+        env_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            'db', 'migration', 'alembic_migrations', 'env.py')
+        fake_context = FakeContext(connection)
+        try:
+            with mock.patch('alembic.context', fake_context):
+                with mock.patch('logging.config.fileConfig'):
+                    runpy.run_path(env_path)
+            self.assertIs(connection, fake_context.configured_connection)
+            self.assertFalse(connection.closed)
+            self.assertTrue(transaction.is_active)
+        finally:
+            if transaction.is_active:
+                transaction.rollback()
+            if not connection.closed:
+                connection.close()
+
+    def test_hashring_params_migration_does_not_commit(self):
+        migration = importlib.import_module(
+            'aim.db.migration.alembic_migrations.versions.'
+            'cf83ad8832f0_hashring_parameters_vnodes')
+
+        class NoCommitSession(object):
+            def execute(self, stmt):
+                pass
+
+            def commit(self):
+                raise AssertionError(
+                    'Alembic migrations must not commit explicitly')
+
+        session = NoCommitSession()
+        with mock.patch.object(migration.op, 'create_table'):
+            with mock.patch.object(migration.op, 'get_bind',
+                                   return_value=mock.Mock()):
+                with mock.patch.object(migration.sa.orm, 'Session',
+                                       return_value=session):
+                    migration.upgrade()
+
+    def test_remoteip_container_migration_does_not_commit(self):
+        migration = importlib.import_module(
+            'aim.db.migration.alembic_migrations.versions.'
+            'a94984a4452b_security_groups_remoteipcont')
+
+        class NoCommitSession(object):
+            def execute(self, stmt):
+                pass
+
+            def commit(self):
+                raise AssertionError(
+                    'Alembic migrations must not commit explicitly')
+
+        session = NoCommitSession()
+        with mock.patch.object(migration.op, 'create_table'):
+            with mock.patch.object(migration.op, 'get_bind',
+                                   return_value=mock.Mock()):
+                with mock.patch.object(migration.sa.orm, 'Session',
+                                       return_value=session):
+                    migration.upgrade()
+
+    def test_bd_ip_learning_migration_does_not_commit(self):
+        migration = importlib.import_module(
+            'aim.db.migration.alembic_migrations.versions.'
+            'dd2f91cf1b1e_set_nat_bd_ip_learn')
+
+        class FakeQuery(object):
+            def all(self):
+                return [(1, 'l3out')]
+
+        class NoCommitSession(object):
+            def query(self, table):
+                return FakeQuery()
+
+            def commit(self):
+                raise AssertionError(
+                    'Alembic migrations must not commit explicitly')
+
+        values = migration.get_bd_l3out_values(NoCommitSession())
+        self.assertEqual([{'bd_aim_id': 1}], values)
+
+
+class TestDBMigrationCommand(base.BaseTestCase):
+
+    def test_fix_no_nat_l3out_ownership_select_is_sqlalchemy_13_safe(self):
+        engine = sa.create_engine('sqlite://')
+        metadata = sa.MetaData()
+        sa.Table(
+            'aim_lib_save_l3out', metadata,
+            sa.Column('tenant_name', sa.String(), primary_key=True),
+            sa.Column('name', sa.String(), primary_key=True),
+            sa.Column('monitored', sa.Boolean()),
+            sa.Column('vrf_name', sa.String()))
+        metadata.create_all(engine)
+        session = db_migration.sa.orm.Session(bind=engine)
+
+        class Store(object):
+            db_session = session
+
+        class AimContext(object):
+            store = Store()
+
+        with mock.patch.object(
+                db_migration.sa, 'select',
+                side_effect=AssertionError(
+                    'Use table.select() for SQLAlchemy 1.3 compatibility')):
+            db_migration.fix_no_nat_l3out_ownership(AimContext())
 
 
 class TestDataMigration(base.TestAimDBBase):

--- a/aim/tests/unit/tools/cli/test_manager.py
+++ b/aim/tests/unit/tools/cli/test_manager.py
@@ -599,7 +599,7 @@ class TestManagerResourceOpsBase(object):
     def _create_prerequisite_objects(self):
         for obj in (self.prereq_objects or []):
             res_command = climanager.convert(type(obj).__name__)
-            if(res_command == 'system-security-group'):
+            if res_command == 'system-security-group':
                 self.run_command('manager ' + res_command + '-create',
                                  raises=False)
             else:

--- a/aim/tools/cli/commands/db_migration.py
+++ b/aim/tools/cli/commands/db_migration.py
@@ -118,7 +118,7 @@ def fix_no_nat_l3out_ownership(aim_ctx):
         if 'aim_lib_save_l3out' not in metadata.tables:
             return
         results = session.execute(
-            sa.select(saved_l3out_table).
+            saved_l3out_table.select().
             where(saved_l3out_table.c.monitored.is_(True)))
         click.echo("Fixing ownership of no-NAT L3Outs")
         rows = results.fetchall()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@
 -e git+https://github.com/noironetworks/acitoolkit.git@noiro-lite#egg=acitoolkit
 -e git+https://github.com/noironetworks/apicapi.git@master#egg=apicapi
 
-hacking>=3.0.0,<4
+hacking>=6.1.0,<7.0.0
 
 cherrypy
 click<=7.1.2
@@ -20,7 +20,7 @@ bcrypt<4.0.0;python_version!='2.7' # MIT License
 decorator<=4.2.1
 python-subunit>=0.0.18
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
-flake8>=3.8.0,<4.0
+flake8>=6.1.0,<7.0.0
 oslosphinx>=2.5.0 # Apache-2.0
 oslotest>=1.10.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -84,6 +84,6 @@ commands = python setup.py test --slowest --testr-args='{posargs}'
 # H202 needed in testing
 
 show-source = True
-ignore = E123,E125,H238,E711,H202,W504,E402,E741,E117,F601,F841,E111,E731
+ignore = E123,E125,H238,E711,H202,W504,E402,E741,E117,F601,F841,E111,E731,H211,H214,H216
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
The DB migration scripts needed changes for compatibility with older and newer versions of SQLAlchemy. A previous commit also had a typo (spelling of 'migration').