### PR TITLE
db: Add oslo.db 18+ support with SQLAlchemy 1.3/1.4/2.x compatibility

### DIFF
--- a/aim/aim_store.py
+++ b/aim/aim_store.py
@@ -19,6 +19,7 @@ from oslo_log import log as logging
 import six
 from sqlalchemy import and_
 from sqlalchemy import event as sa_event
+from sqlalchemy import exc as sa_exc
 from sqlalchemy import or_
 from sqlalchemy.sql.expression import func
 
@@ -347,7 +348,8 @@ class SqlAlchemyStore(AimStore):
             if hasattr(sess, "in_transaction"):
                 return sess.in_transaction()
             try:
-                return sess.transaction is not None
+                tx = sess.transaction
+                return tx is not None and getattr(tx, 'is_active', False)
             except AttributeError:
                 return False
 
@@ -362,7 +364,15 @@ class SqlAlchemyStore(AimStore):
         return True
 
     def begin(self, **kwargs):
-        return self.db_session.begin()
+        try:
+            return self.db_session.begin()
+        except sa_exc.InvalidRequestError:
+            # SQLAlchemy 1.3 nested begin requires subtransactions.
+            try:
+                return self.db_session.begin(subtransactions=True)
+            except TypeError:
+                # SQLAlchemy 1.4+ removed subtransactions.
+                return _begin(**kwargs)
 
     def resource_to_db_type(self, resource_klass):
         return self.db_model_map.get(resource_klass)

--- a/aim/db/api.py
+++ b/aim/db/api.py
@@ -14,48 +14,85 @@
 #    under the License.
 
 from oslo_config import cfg
-from oslo_db.sqlalchemy import session
+from oslo_db import options as db_options
+try:
+    from oslo_db.sqlalchemy import session as db_session
+except ImportError:  # oslo.db without legacy session facade support
+    db_session = None
+from oslo_db.sqlalchemy import enginefacade
 
 from aim import aim_store
 
+cfg.CONF.register_opts(db_options.database_opts, group='database')
 
 _FACADE = None
+_ENGINE = None
+_SESSIONMAKER = None
+_LEGACY_ENGINE_FACADE = getattr(db_session, 'EngineFacade', None)
 
 
-def _create_facade_lazily():
-    global _FACADE
+def _configure():
+    global _FACADE, _ENGINE, _SESSIONMAKER
 
-    if _FACADE is None:
-        _FACADE = session.EngineFacade.from_config(cfg.CONF, sqlite_fk=True)
+    if _FACADE is not None:
+        return
 
-    return _FACADE
+    if _LEGACY_ENGINE_FACADE is not None:
+        _FACADE = _LEGACY_ENGINE_FACADE.from_config(
+            cfg.CONF, sqlite_fk=True)
+        return
+
+    _FACADE = enginefacade.transaction_context()
+    _FACADE.configure(sqlite_fk=True)
+
+    _ENGINE = _FACADE.writer.get_engine()
+    _SESSIONMAKER = _FACADE.writer.get_sessionmaker()
 
 
 def get_engine():
     """Helper method to grab engine."""
-    facade = _create_facade_lazily()
-    return facade.get_engine()
+    _configure()
+    if _ENGINE is not None:
+        return _ENGINE
+    return _FACADE.get_engine()
 
 
 def dispose():
     # Don't need to do anything if an enginefacade hasn't been created
-    if _FACADE is not None:
-        get_engine().pool.dispose()
+    if _ENGINE is not None:
+        _ENGINE.pool.dispose()
+    elif _FACADE is not None:
+        _FACADE.get_engine().pool.dispose()
 
 
-def get_session(expire_on_commit=True, use_slave=False):
+def get_session(autocommit=True, expire_on_commit=True, use_slave=False):
     """Helper method to grab session."""
-    facade = _create_facade_lazily()
-    return facade.get_session(expire_on_commit=expire_on_commit,
-                              use_slave=use_slave)
+    _configure()
+    if _SESSIONMAKER is not None:
+        # The newer transaction_context path does not expose use_slave/
+        # autocommit controls.
+        return _SESSIONMAKER(expire_on_commit=expire_on_commit)
+    try:
+        return _FACADE.get_session(autocommit=autocommit,
+                                   expire_on_commit=expire_on_commit,
+                                   use_slave=use_slave)
+    except TypeError:
+        # Some legacy facade/version combinations may not support
+        # autocommit in the signature.
+        return _FACADE.get_session(expire_on_commit=expire_on_commit,
+                                   use_slave=use_slave)
 
 
-def get_store(expire_on_commit=True, use_slave=False):
+def get_store(autocommit=True, expire_on_commit=True, use_slave=False):
     store = cfg.CONF.aim.aim_store
+
     if store == 'sql':
-        db_session = get_session(expire_on_commit=expire_on_commit,
-                                 use_slave=use_slave)
+        db_session = get_session(
+            autocommit=autocommit,
+            expire_on_commit=expire_on_commit,
+            use_slave=use_slave)
         return aim_store.SqlAlchemyStore(db_session)
+
     elif store == 'k8s':
         return aim_store.K8sStore(
             namespace=cfg.CONF.aim_k8s.k8s_namespace,

--- a/aim/db/config_model.py
+++ b/aim/db/config_model.py
@@ -64,22 +64,21 @@ class ConfigurationDBManager(object):
         if hasattr(sess, "in_transaction"):
             return sess.in_transaction()
         try:
-            return sess.transaction is not None
+            tx = sess.transaction
+            return tx is not None and getattr(tx, 'is_active', False)
         except AttributeError:
             return False
 
     def _get(self, context, group, key, host='', **kwargs):
-        with context.store.begin():
-            curr = self.aim_mgr.get(
-                context, resource.Configuration(group=group, key=key,
-                                                host=host))
-            if curr:
-                return curr
-            else:
-                if 'default' in kwargs:
-                    return kwargs['default']
-                raise exc.ConfigurationUndefined(group=group, conf=key,
-                                                 host=host)
+        curr = self.aim_mgr.get(
+            context, resource.Configuration(group=group, key=key,
+                                            host=host))
+        if curr:
+            return curr
+        if 'default' in kwargs:
+            return kwargs['default']
+        raise exc.ConfigurationUndefined(group=group, conf=key,
+                                         host=host)
 
     @utils.log
     def update_bulk(self, context, configs):

--- a/aim/db/hashtree_db_listener.py
+++ b/aim/db/hashtree_db_listener.py
@@ -49,7 +49,8 @@ class HashTreeDbListener(object):
         if hasattr(sess, "in_transaction"):
             return sess.in_transaction()
         try:
-            return sess.transaction is not None
+            tx = sess.transaction
+            return tx is not None and getattr(tx, 'is_active', False)
         except AttributeError:
             return False
 
@@ -83,7 +84,10 @@ class HashTreeDbListener(object):
                     root_rn=root, action=action,
                     object_dict=utils.json_dumps(res.__dict__),
                     object_type=type(res).__name__)
-                self.aim_manager._create(ctx, log)
+                # This method runs from the SQLAlchemy before_flush hook.
+                # Avoid issuing extra ORM reads here, since they can interfere
+                # with active cursor/result handling on SQLAlchemy 1.3.
+                ctx.store.add(ctx.store.make_db_obj(log))
 
     def on_commit(self, store, added, updated, deleted):
         with store.db_session.begin():

--- a/aim/tests/base.py
+++ b/aim/tests/base.py
@@ -149,7 +149,8 @@ def _initialize_hooks(self):
 
 def _catch_up_logs(self, added, updated, removed):
     # Create new session and populate the hashtrees
-    session = api.get_session(expire_on_commit=True,
+    session = api.get_session(autocommit=False,
+                              expire_on_commit=True,
                               use_slave=False)
     store = aim_store.SqlAlchemyStore(session)
     ht_db_l.HashTreeDbListener(

--- a/aim/tools/cli/commands/db_migration.py
+++ b/aim/tools/cli/commands/db_migration.py
@@ -18,6 +18,7 @@ import os
 import click
 from oslo_db.sqlalchemy.migration_cli import manager
 import sqlalchemy as sa
+from sqlalchemy import exc as sa_exc
 
 from aim.agent.aid.universes.aci import aci_universe
 from aim import aim_manager
@@ -113,7 +114,13 @@ def fix_no_nat_l3out_ownership(aim_ctx):
         sa.Column('vrf_name', nullable=True))
     session = aim_ctx.store.db_session
     bind = session.get_bind()
-    with session.begin():
+    try:
+        tx_ctx = session.begin()
+    except sa_exc.InvalidRequestError:
+        # SQLAlchemy 1.3 requires subtransactions for nested begin().
+        tx_ctx = session.begin(subtransactions=True)
+
+    with tx_ctx:
         metadata.reflect(bind=bind)
         if 'aim_lib_save_l3out' not in metadata.tables:
             return

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -24,7 +24,6 @@ flake8>=6.1.0,<7.0.0
 oslosphinx>=2.5.0 # Apache-2.0
 oslotest>=1.10.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
-oslo.db<18
 testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py27-constraints,pypy-constraints,pep8-constraints,pep8,py38,py310,py312
+envlist = py27-constraints,pypy-constraints,pep8-constraints,pep8,py39,py310,py312
 skipsdist = True
 
 [testenv]
@@ -16,6 +16,12 @@ deps =
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/test-requirements.txt
 commands = stestr run --slowest {posargs}
+
+[testenv:py39]
+deps =
+   SQLAlchemy<2
+   -r{toxinidir}/requirements.txt
+   -r{toxinidir}/test-requirements.txt
 
 [testenv:common-constraints]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
aim/db/api.py: Replace deprecated `EngineFacade.from_config()` with `enginefacade.transaction_context()`, retaining a legacy fallback for older `oslo.db` releases. Add backward-compatible session arguments.

aim/aim_store.py: Fix transaction detection and nested transaction handling for SQLAlchemy 1.3/1.4.

aim/db/config_model.py, aim/db/hashtree_db_listener.py: Improve transaction handling to avoid session rollback during host-fallback configuration lookups and ORM read-after-write queries during `before_flush`.

aim/tests/base.py: Use `autocommit=False` to prevent recursive transaction callbacks.

aim/tools/cli/commands/db_migration.py: Handle nested transactions for SQLAlchemy 1.3 compatibility.